### PR TITLE
experimental: run applescript on separate serial queue

### DIFF
--- a/MTMR/AppleScriptTouchBarItem.swift
+++ b/MTMR/AppleScriptTouchBarItem.swift
@@ -15,7 +15,7 @@ class AppleScriptTouchBarItem: CustomButtonTouchBarItem {
         }
         self.script = script
         button.bezelColor = .clear
-        DispatchQueue.main.async {
+        DispatchQueue.appleScriptQueue.async {
             var error: NSDictionary?
             guard script.compileAndReturnError(&error) else {
                 #if DEBUG
@@ -42,8 +42,11 @@ class AppleScriptTouchBarItem: CustomButtonTouchBarItem {
         DispatchQueue.main.async {
             self.title = scriptResult
             self.forceHideConstraint.isActive = scriptResult == ""
+            #if DEBUG
+            print("did set new script result title \(scriptResult)")
+            #endif
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + self.interval) { [weak self] in
+        DispatchQueue.appleScriptQueue.asyncAfter(deadline: .now() + self.interval) { [weak self] in
             self?.refreshAndSchedule()
         }
     }
@@ -65,4 +68,8 @@ extension SourceProtocol {
         guard let source = self.string else { return nil }
         return NSAppleScript(source: source)
     }
+}
+
+extension DispatchQueue {
+    static let appleScriptQueue = DispatchQueue(label: "mtmr.applescript")
 }

--- a/MTMR/TouchBarController.swift
+++ b/MTMR/TouchBarController.swift
@@ -262,10 +262,12 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
                 return {}
             }
             return {
-                var error: NSDictionary?
-                appleScript.executeAndReturnError(&error)
-                if let error = error {
-                    print("error \(error) when handling \(item) ")
+                DispatchQueue.appleScriptQueue.async {
+                    var error: NSDictionary?
+                    appleScript.executeAndReturnError(&error)
+                    if let error = error {
+                        print("error \(error) when handling \(item) ")
+                    }
                 }
             }
         case .shellScript(executable: let executable, parameters: let parameters):


### PR DESCRIPTION
Previous time I had separate queue for every widget, now only one, so missing thread-safety might be no longer an issue. 

Requires testing