### PR TITLE
Having no timeZone setup makes MTMR crash.

### DIFF
--- a/MTMR/ItemsParsing.swift
+++ b/MTMR/ItemsParsing.swift
@@ -393,7 +393,7 @@ enum ItemType: Decodable {
 
         case .timeButton:
             let template = try container.decodeIfPresent(String.self, forKey: .formatTemplate) ?? "HH:mm"
-            let timeZone = try container.decodeIfPresent(String.self, forKey: .timeZone) ?? nil
+            let timeZone = try? container.decodeIfPresent(String.self, forKey: .timeZone) ?? "UTC"
             self = .timeButton(formatTemplate: template, timeZone: timeZone!)
 
         case .battery:


### PR DESCRIPTION
I've updated to 0.19.2 and it keeps crashing constantly, then I figured out that I'm usign timeButton but haven't defined (newly introduced) timeZone variable.

This commit fixes the crash.