### PR TITLE
Added an additional option for the dock to automatically resize

### DIFF
--- a/MTMR.xcodeproj/project.pbxproj
+++ b/MTMR.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 				6027D1B72080E52A004FFDC7 /* BrightnessViewController.swift */,
 				607EEA4C2087A8DA009DA5F0 /* CurrencyBarItem.swift */,
 				B081732B213739FE005D4908 /* DnDBarItem.swift */,
+				60669B4220AD8FA80074E817 /* GroupBarItem.swift */,
 				60F7D453208CC31400ABF5D2 /* InputSourceBarItem.swift */,
 				60C44AFC20A373A100C0EC91 /* MusicBarItem.swift */,
 				B0846A742220C968000288A7 /* NetworkBarItem.swift */,
@@ -292,7 +293,6 @@
 				6027D1B82080E52A004FFDC7 /* VolumeViewController.swift */,
 				607EEA4A2087835F009DA5F0 /* WeatherBarItem.swift */,
 				B08126F0217BE19000A98970 /* WidgetProtocol.swift */,
-				60669B4220AD8FA80074E817 /* GroupBarItem.swift */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
@@ -633,7 +633,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = P5KK92AA97;
+				DEVELOPMENT_TEAM = D6D8BR2QNB;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",

--- a/MTMR.xcodeproj/project.pbxproj
+++ b/MTMR.xcodeproj/project.pbxproj
@@ -283,7 +283,6 @@
 				6027D1B72080E52A004FFDC7 /* BrightnessViewController.swift */,
 				607EEA4C2087A8DA009DA5F0 /* CurrencyBarItem.swift */,
 				B081732B213739FE005D4908 /* DnDBarItem.swift */,
-				60669B4220AD8FA80074E817 /* GroupBarItem.swift */,
 				60F7D453208CC31400ABF5D2 /* InputSourceBarItem.swift */,
 				60C44AFC20A373A100C0EC91 /* MusicBarItem.swift */,
 				B0846A742220C968000288A7 /* NetworkBarItem.swift */,
@@ -293,6 +292,7 @@
 				6027D1B82080E52A004FFDC7 /* VolumeViewController.swift */,
 				607EEA4A2087835F009DA5F0 /* WeatherBarItem.swift */,
 				B08126F0217BE19000A98970 /* WidgetProtocol.swift */,
+				60669B4220AD8FA80074E817 /* GroupBarItem.swift */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
@@ -633,7 +633,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = D6D8BR2QNB;
+				DEVELOPMENT_TEAM = P5KK92AA97;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",

--- a/MTMR/Base.lproj/Main.storyboard
+++ b/MTMR/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -619,7 +619,7 @@
                                         <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
-                                                <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">

--- a/MTMR/Info.plist
+++ b/MTMR/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.20.3</string>
 	<key>CFBundleVersion</key>
-	<string>226</string>
+	<string>250</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MTMR/Info.plist
+++ b/MTMR/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.20.3</string>
 	<key>CFBundleVersion</key>
-	<string>223</string>
+	<string>226</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MTMR/Info.plist
+++ b/MTMR/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.20.3</string>
 	<key>CFBundleVersion</key>
-	<string>201</string>
+	<string>220</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MTMR/Info.plist
+++ b/MTMR/Info.plist
@@ -19,11 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-<<<<<<< HEAD
 	<string>250</string>
-=======
-	<string>185</string>
->>>>>>> origin/master
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MTMR/Info.plist
+++ b/MTMR/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.20.3</string>
 	<key>CFBundleVersion</key>
-	<string>220</string>
+	<string>223</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MTMR/ItemsParsing.swift
+++ b/MTMR/ItemsParsing.swift
@@ -197,9 +197,12 @@ class SupportedTypesHolder {
             )
         },
 
-        "dock": { _ in
-            (
-                item: .dock(),
+        "dock": { decoder in
+            enum CodingKeys: String, CodingKey { case autoResize }
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let autoResize = try container.decodeIfPresent(Bool.self, forKey: .autoResize) ?? false
+            return (
+                item: .dock(autoResize: autoResize),
                 action: .none,
                 longAction: .none,
                 parameters: [:]
@@ -327,7 +330,7 @@ enum ItemType: Decodable {
     case appleScriptTitledButton(source: SourceProtocol, refreshInterval: Double)
     case timeButton(formatTemplate: String, timeZone: String?)
     case battery()
-    case dock()
+    case dock(autoResize: Bool)
     case volume()
     case brightness(refreshInterval: Double)
     case weather(interval: Double, units: String, api_key: String, icon_type: String)
@@ -360,6 +363,7 @@ enum ItemType: Decodable {
         case workTime
         case restTime
         case flip
+        case autoResize
     }
 
     enum ItemTypeRaw: String, Decodable {
@@ -403,7 +407,8 @@ enum ItemType: Decodable {
             self = .battery()
 
         case .dock:
-            self = .dock()
+            let autoResize = try container.decodeIfPresent(Bool.self, forKey: .autoResize) ?? false
+            self = .dock(autoResize: autoResize)
 
         case .volume:
             self = .volume()

--- a/MTMR/TouchBarController.swift
+++ b/MTMR/TouchBarController.swift
@@ -27,7 +27,7 @@ extension ItemType {
             return "com.toxblh.mtmr.timeButton."
         case .battery():
             return "com.toxblh.mtmr.battery."
-        case .dock():
+        case .dock(autoResize: _):
             return "com.toxblh.mtmr.dock"
         case .volume():
             return "com.toxblh.mtmr.volume"
@@ -251,8 +251,8 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
             barItem = TimeTouchBarItem(identifier: identifier, formatTemplate: template, timeZone: timeZone)
         case .battery():
             barItem = BatteryBarItem(identifier: identifier)
-        case .dock:
-            barItem = AppScrubberTouchBarItem(identifier: identifier)
+        case let .dock(autoResize: autoResize):
+            barItem = AppScrubberTouchBarItem(identifier: identifier, autoResize: autoResize)
         case .volume:
             if case let .image(source)? = item.additionalParameters[.image] {
                 barItem = VolumeViewController(identifier: identifier, image: source.image)

--- a/MTMR/Widgets/AppScrubberTouchBarItem.swift
+++ b/MTMR/Widgets/AppScrubberTouchBarItem.swift
@@ -17,6 +17,7 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
     private let minTicks: Int = 5
     private let maxTicks: Int = 20
     private var lastSelected: Int = 0
+    private var autoResize: Bool = false
 
     private var persistentAppIdentifiers: [String] = []
     private var runningAppsIdentifiers: [String] = []
@@ -27,10 +28,15 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
     }
 
     private var applications: [DockItem] = []
+    
+    convenience override init(identifier: NSTouchBarItem.Identifier) {
+        self.init(identifier: identifier, autoResize: false)
+    }
 
-    override init(identifier: NSTouchBarItem.Identifier) {
+    init(identifier: NSTouchBarItem.Identifier, autoResize: Bool) {
         super.init(identifier: identifier)
-
+        self.autoResize = autoResize
+        
         scrubber = NSScrubber()
         scrubber.delegate = self
         scrubber.dataSource = self

--- a/MTMR/Widgets/AppScrubberTouchBarItem.swift
+++ b/MTMR/Widgets/AppScrubberTouchBarItem.swift
@@ -18,6 +18,7 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
     private let maxTicks: Int = 20
     private var lastSelected: Int = 0
     private var autoResize: Bool = false
+    private var widthConstraint: NSLayoutConstraint?
 
     private var persistentAppIdentifiers: [String] = []
     private var runningAppsIdentifiers: [String] = []
@@ -87,16 +88,21 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
 
         applications = newApplications
         applications += getDockPersistentAppsList()
-        updateSize()
         scrubber.reloadData()
+        updateSize()
 
         scrubber.selectedIndex = index ?? 0
     }
     
     func updateSize() {
         if self.autoResize {
+            if let constraint: NSLayoutConstraint = self.widthConstraint {
+                constraint.isActive = false
+                self.scrubber.removeConstraint(constraint)
+            }
             let width = (AppScrubberTouchBarItem.iconWidth + AppScrubberTouchBarItem.spacingWidth) * self.applications.count - AppScrubberTouchBarItem.spacingWidth
-            self.setWidth(value: CGFloat(width))
+            self.widthConstraint = self.scrubber.widthAnchor.constraint(equalToConstant: CGFloat(width))
+            self.widthConstraint!.isActive = true
         }
     }
 

--- a/MTMR/Widgets/AppScrubberTouchBarItem.swift
+++ b/MTMR/Widgets/AppScrubberTouchBarItem.swift
@@ -32,6 +32,9 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
     convenience override init(identifier: NSTouchBarItem.Identifier) {
         self.init(identifier: identifier, autoResize: false)
     }
+    
+    static var iconWidth = 36
+    static var spacingWidth = 2
 
     init(identifier: NSTouchBarItem.Identifier, autoResize: Bool) {
         super.init(identifier: identifier)
@@ -42,8 +45,8 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
         scrubber.dataSource = self
         scrubber.mode = .free // .fixed
         let layout = NSScrubberFlowLayout()
-        layout.itemSize = NSSize(width: 36, height: 32)
-        layout.itemSpacing = 2
+        layout.itemSize = NSSize(width: AppScrubberTouchBarItem.iconWidth, height: 32)
+        layout.itemSpacing = CGFloat(AppScrubberTouchBarItem.spacingWidth)
         scrubber.scrubberLayout = layout
         scrubber.selectionBackgroundStyle = .roundedBackground
         scrubber.showsAdditionalContentIndicators = true
@@ -84,9 +87,17 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
 
         applications = newApplications
         applications += getDockPersistentAppsList()
+        updateSize()
         scrubber.reloadData()
 
         scrubber.selectedIndex = index ?? 0
+    }
+    
+    func updateSize() {
+        if self.autoResize {
+            let width = (AppScrubberTouchBarItem.iconWidth + AppScrubberTouchBarItem.spacingWidth) * self.applications.count - AppScrubberTouchBarItem.spacingWidth
+            self.setWidth(value: CGFloat(width))
+        }
     }
 
     public func numberOfItems(for _: NSScrubber) -> Int {

--- a/README.md
+++ b/README.md
@@ -199,6 +199,15 @@ To close a group, use the button:
 },
 ```
 
+#### `dock`
+> Dock plugin
+```js
+{
+  "type": "dock",
+  "autoResize": true
+},
+```
+
 ## Actions:
 - `hidKey`
 > https://github.com/aosm/IOHIDFamily/blob/master/IOHIDSystem/IOKit/hidsystem/ev_keymap.h use only numbers


### PR DESCRIPTION
The additional option can be configured within the items.json file by adding an optional "autoResize" parameter. The default for this option is false, which leaves the functionality of the dock unchanged from before I added this feature.
If "autoResize" in the dock is set to true however, the dock updates its NSScrubber length to be the length of all items within the dock. This makes it such that the dock is no longer a scrollable region, but a region of unfixed length

I used autoResize in my own setup (see attached)
<img width="1085" alt="Touch Bar Shot 2019-05-09 at 10 57 37 PM" src="https://user-images.githubusercontent.com/40780864/57563289-1f870b80-7351-11e9-8891-cac680b8587c.png">
<img width="1085" alt="Touch Bar Shot 2019-05-09 at 10 57 54 PM" src="https://user-images.githubusercontent.com/40780864/57563290-201fa200-7351-11e9-96b7-6ff0cc8c2f08.png">
In my setup, I had my dock, spotify, and media controls configured to align to center, putting them all within a scrollable region. However, because the dock was in the scrollable region, there would be nested scrollable regions, which had annoyed me. But by having the dock autoresize and be variable width, the dock would no longer be scrollable, allowing me to have one long and fluid scrollable region as shown in my attached image.

