### PR TITLE
Activate Finder

### DIFF
--- a/MTMR/AppleScripts/Finder.scpt
+++ b/MTMR/AppleScripts/Finder.scpt
@@ -1,5 +1,7 @@
 tell application "Finder"
-	make new Finder window
-	set target of front window to path to home folder as string
+	if not (exists window 1) then
+		make new Finder window
+		set target of front window to path to home folder as string
+	end if
 	activate
 end tell

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The pre-installed configuration contains less or more than you'll probably want,
     "source": {
       "filePath": "/Users/toxblh/Library/Application Support/MTMR/iTunes.nowPlaying.scpt",
       // or
-      "inline": "tell application \"Finder\"\rif exists window 1 then\ractivate\relse\rmake new Finder window\rset target of front window to path to home folder as string\ractivate\rend if\rend tell",
+      "inline": "tell application \"Finder\"\rif not (exists window 1) then\rmake new Finder window\rset target of front window to path to home folder as string\rend if\ractivate\rend tell",
       // or
       "base64": "StringInbase64"
     }
@@ -314,7 +314,7 @@ To close a group, use the button:
 ```js
  "action": "appleScript",
  "actionAppleScript": {
-     "inline": "tell application \"Finder\"\rmake new Finder window\rset target of front window to path to home folder as string\ractivate\rend tell"
+      "inline": "tell application \"Finder\"\rif not (exists window 1) then\rmake new Finder window\rset target of front window to path to home folder as string\rend if\ractivate\rend tell",
     // "filePath" or "base64" will work as well
  },
 ```

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The pre-installed configuration contains less or more than you'll probably want,
     "source": {
       "filePath": "/Users/toxblh/Library/Application Support/MTMR/iTunes.nowPlaying.scpt",
       // or
-      "inline": "tell application \"Finder\"\rmake new Finder window\rset target of front window to path to home folder as string\ractivate\rend tell",
+      "inline": "tell application \"Finder\"\rif exists window 1 then\ractivate\relse\rmake new Finder window\rset target of front window to path to home folder as string\ractivate\rend if\rend tell",
       // or
       "base64": "StringInbase64"
     }


### PR DESCRIPTION
Bring existing Finder window to front, or open a new window.
This avoids opening multiple Finder windows on consecutive press 