### PR TITLE
Dock improvements

### DIFF
--- a/MTMR/AppSettings.swift
+++ b/MTMR/AppSettings.swift
@@ -12,6 +12,9 @@ struct AppSettings {
     
     @UserDefault(key: "com.toxblh.mtmr.blackListedApps", defaultValue: [])
     static var blacklistedAppIds: [String]
+    
+    @UserDefault(key: "com.toxblh.mtmr.dock.persistent", defaultValue: [])
+    static var dockPersistentAppIds: [String]
 }
 
 @propertyWrapper

--- a/MTMR/CustomButtonTouchBarItem.swift
+++ b/MTMR/CustomButtonTouchBarItem.swift
@@ -15,6 +15,7 @@ class CustomButtonTouchBarItem: NSCustomTouchBarItem, NSGestureRecognizerDelegat
             longClick.isEnabled = longTapClosure != nil
         }
     }
+    var finishViewConfiguration: ()->() = {}
     
     private var button: NSButton!
     private var singleClick: HapticClickGestureRecognizer!
@@ -100,6 +101,7 @@ class CustomButtonTouchBarItem: NSCustomTouchBarItem, NSGestureRecognizerDelegat
 
         view.addGestureRecognizer(longClick)
         view.addGestureRecognizer(singleClick)
+        finishViewConfiguration()
     }
 
     func gestureRecognizer(_ gestureRecognizer: NSGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: NSGestureRecognizer) -> Bool {

--- a/MTMR/CustomButtonTouchBarItem.swift
+++ b/MTMR/CustomButtonTouchBarItem.swift
@@ -189,7 +189,7 @@ class HapticClickGestureRecognizer: NSClickGestureRecognizer {
 }
 
 class LongPressGestureRecognizer: NSPressGestureRecognizer {
-    private let recognizeTimeout = 0.4
+    var recognizeTimeout = 0.4
     private var timer: Timer?
     
     override func touchesBegan(with event: NSEvent) {

--- a/MTMR/ItemsParsing.swift
+++ b/MTMR/ItemsParsing.swift
@@ -211,18 +211,6 @@ class SupportedTypesHolder {
             )
         },
 
-        "dock": { decoder in
-            enum CodingKeys: String, CodingKey { case autoResize }
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            let autoResize = try container.decodeIfPresent(Bool.self, forKey: .autoResize) ?? false
-            return (
-                item: .dock(autoResize: autoResize),
-                action: .none,
-                longAction: .none,
-                parameters: [:]
-            )
-        },
-
         "inputsource": { _ in
             (
                 item: .inputsource,
@@ -346,7 +334,7 @@ enum ItemType: Decodable {
     case shellScriptTitledButton(source: SourceProtocol, refreshInterval: Double)
     case timeButton(formatTemplate: String, timeZone: String?, locale: String?)
     case battery
-    case dock(autoResize: Bool)
+    case dock(autoResize: Bool, filter: String?)
     case volume
     case brightness(refreshInterval: Double)
     case weather(interval: Double, units: String, api_key: String, icon_type: String)
@@ -383,6 +371,7 @@ enum ItemType: Decodable {
         case restTime
         case flip
         case autoResize
+        case filter
         case disableMarquee
     }
 
@@ -437,7 +426,8 @@ enum ItemType: Decodable {
 
         case .dock:
             let autoResize = try container.decodeIfPresent(Bool.self, forKey: .autoResize) ?? false
-            self = .dock(autoResize: autoResize)
+            let filterRegexString = try container.decodeIfPresent(String.self, forKey: .filter)
+            self = .dock(autoResize: autoResize, filter: filterRegexString)
 
         case .volume:
             self = .volume

--- a/MTMR/TouchBarController.swift
+++ b/MTMR/TouchBarController.swift
@@ -29,7 +29,7 @@ extension ItemType {
             return "com.toxblh.mtmr.timeButton."
         case .battery:
             return "com.toxblh.mtmr.battery."
-        case .dock(autoResize: _):
+        case .dock(autoResize: _, filter: _):
             return "com.toxblh.mtmr.dock"
         case .volume:
             return "com.toxblh.mtmr.volume"
@@ -248,8 +248,16 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
             barItem = TimeTouchBarItem(identifier: identifier, formatTemplate: template, timeZone: timeZone, locale: locale)
         case .battery:
             barItem = BatteryBarItem(identifier: identifier)
-        case let .dock(autoResize: autoResize):
-            barItem = AppScrubberTouchBarItem(identifier: identifier, autoResize: autoResize)
+        case let .dock(autoResize: autoResize, filter: regexString):
+            if let regexString = regexString {
+                guard let regex = try? NSRegularExpression(pattern: regexString, options: []) else {
+                    barItem = CustomButtonTouchBarItem(identifier: identifier, title: "Bad regex")
+                    break
+                }
+                barItem = AppScrubberTouchBarItem(identifier: identifier, autoResize: autoResize, filter: regex)
+            } else {
+                barItem = AppScrubberTouchBarItem(identifier: identifier, autoResize: autoResize)
+            }
         case .volume:
             if case let .image(source)? = item.additionalParameters[.image] {
                 barItem = VolumeViewController(identifier: identifier, image: source.image)

--- a/MTMR/Widgets/AppScrubberTouchBarItem.swift
+++ b/MTMR/Widgets/AppScrubberTouchBarItem.swift
@@ -58,10 +58,7 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
         NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(activeApplicationChanged), name: NSWorkspace.didTerminateApplicationNotification, object: nil)
         NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(activeApplicationChanged), name: NSWorkspace.didActivateApplicationNotification, object: nil)
 
-        if let persistent = UserDefaults.standard.stringArray(forKey: "com.toxblh.mtmr.dock.persistent") {
-            persistentAppIdentifiers = persistent
-        }
-
+        persistentAppIdentifiers = AppSettings.dockPersistentAppIds
         updateRunningApplication()
     }
 
@@ -208,8 +205,7 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem, NSScrubberDelegate, NSScrub
                 persistentAppIdentifiers.append(bundleIdentifier!)
             }
 
-            UserDefaults.standard.set(persistentAppIdentifiers, forKey: "com.toxblh.mtmr.dock.persistent")
-            UserDefaults.standard.synchronize()
+            AppSettings.dockPersistentAppIds = persistentAppIdentifiers
         }
         ticks = 0
         updateRunningApplication()

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ To close a group, use the button:
 ```js
 {
   "type": "dock",
+  "filter": "(^Xcode$)|(Safari)|(.*player)",
   "autoResize": true
 },
 ```


### PR DESCRIPTION
* extract to settings
* cleanup in config parser (there were two parts reading the same, one was never executed)
* implement filter for dock items
* rewrite from NSScrubber to NSScrollView. mainly to fix open/terminate of the wrong app (not the one being touched), but also to fix extra dock reloads 
* more stylish frontmost app indicator 


<img width="115" alt="Touch Bar Shot 2019-10-27 at 15 34 43" src="https://user-images.githubusercontent.com/458005/67631930-5d5ff800-f8cf-11e9-863a-49dc0bfbdabe.png">
