### PR TITLE
Implemented changable icons for AppleScriptTouchBarItem

### DIFF
--- a/MTMR/ItemsParsing.swift
+++ b/MTMR/ItemsParsing.swift
@@ -208,7 +208,7 @@ class SupportedTypesHolder {
 
 enum ItemType: Decodable {
     case staticButton(title: String)
-    case appleScriptTitledButton(source: SourceProtocol, refreshInterval: Double)
+    case appleScriptTitledButton(source: SourceProtocol, refreshInterval: Double, alternativeImages: [String: SourceProtocol])
     case shellScriptTitledButton(source: SourceProtocol, refreshInterval: Double)
     case timeButton(formatTemplate: String, timeZone: String?, locale: String?)
     case battery
@@ -251,6 +251,7 @@ enum ItemType: Decodable {
         case autoResize
         case filter
         case disableMarquee
+        case alternativeImages
     }
 
     enum ItemTypeRaw: String, Decodable {
@@ -282,7 +283,8 @@ enum ItemType: Decodable {
         case .appleScriptTitledButton:
             let source = try container.decode(Source.self, forKey: .source)
             let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 1800.0
-            self = .appleScriptTitledButton(source: source, refreshInterval: interval)
+            let alternativeImages = try container.decodeIfPresent([String: Source].self, forKey: .alternativeImages) ?? [:]
+            self = .appleScriptTitledButton(source: source, refreshInterval: interval, alternativeImages: alternativeImages)
             
         case .shellScriptTitledButton:
             let source = try container.decode(Source.self, forKey: .source)

--- a/MTMR/TouchBarController.swift
+++ b/MTMR/TouchBarController.swift
@@ -240,8 +240,8 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
         switch item.type {
         case let .staticButton(title: title):
             barItem = CustomButtonTouchBarItem(identifier: identifier, title: title)
-        case let .appleScriptTitledButton(source: source, refreshInterval: interval):
-            barItem = AppleScriptTouchBarItem(identifier: identifier, source: source, interval: interval)
+        case let .appleScriptTitledButton(source: source, refreshInterval: interval, alternativeImages: alternativeImages):
+            barItem = AppleScriptTouchBarItem(identifier: identifier, source: source, interval: interval, alternativeImages: alternativeImages)
         case let .shellScriptTitledButton(source: source, refreshInterval: interval):
             barItem = ShellScriptTouchBarItem(identifier: identifier, source: source, interval: interval)
         case let .timeButton(formatTemplate: template, timeZone: timeZone, locale: locale):

--- a/README.md
+++ b/README.md
@@ -133,8 +133,35 @@ The pre-installed configuration contains less or more than you'll probably want,
       "inline": "tell application \"Finder\"\rif not (exists window 1) then\rmake new Finder window\rset target of front window to path to home folder as string\rend if\ractivate\rend tell",
       // or
       "base64": "StringInbase64"
-    }
+    },
   }
+```
+
+> Note: appleScriptTitledButton can change its icon. To do it, you need to do the following things:
+1. Declarate dictionary of icons in `alternativeImages` field
+2. Make you script return array of two values - `{"TITLE", "IMAGE_LABEL"}`
+3. Make sure that your `IMAGE_LABEL` is declared in `alternativeImages` field
+
+Example:
+```js
+  {
+    "type": "appleScriptTitledButton",
+    "source": {
+      "inline": "if (random number from 1 to 2) = 1 then\n\tset val to {\"title\", \"play\"}\nelse\n\tset val to {\"title\", \"pause\"}\nend if\nreturn val"
+    },
+    "refreshInterval": 1,
+    "image": {
+      "base64": "iVBORw0KGgoAAAANSUhEUgA..."
+    },
+    "alternativeImages": {
+      "play": {
+        "base64": "iVBORw0KGgoAAAANSUhEUgAAAAAA..."
+      },
+      "pause": {
+        "base64": "iVBORw0KGgoAAAANSUhEUgAAAIAA..."
+      }
+    }
+  },
 ```
 
 #### `shellScriptTitledButton`


### PR DESCRIPTION
AppleScriptTouchBarItem now allow to specify any number of icons which can be changed from the script. 

To do it, you need to return an array of two elements {"TITLE", "ICON_NAME"} from apple script instead of just a string with title. When array is returned, we take second element of the array, pick the corresponding icon from "alternativeIcons" and update it.

Example of usage:
```
{
    "type": "appleScriptTitledButton",
    "source": {
      "inline": "if (random number from 1 to 2) = 1 then\n\tset val to {\"title\", \"play\"}\nelse\n\tset val to {\"title\", \"pause\"}\nend if\nreturn val"
    },
    "refreshInterval": 1,
    "image": {
      "base64": "iVBORw0KGgoAAAANSUhEUgA..."
    },
    "alternativeImages": {
      "play": {
        "base64": "iVBORw0KGgoAAAANSUhEUgAAAAAA..."
      },
      "pause": {
        "base64": "iVBORw0KGgoAAAANSUhEUgAAAIAA..."
      }
    }
  },
```

This element would randomly change it icon from `alternativeImages["play"]` to `alternativeImages["pause"]` and back. 

All old script would still work as before.