### PR TITLE
Refactored preset parsing

### DIFF
--- a/MTMR/BasicView.swift
+++ b/MTMR/BasicView.swift
@@ -15,6 +15,7 @@ class BasicView: NSCustomTouchBarItem, NSGestureRecognizerDelegate {
     var threefingers: NSPanGestureRecognizer!
     var fourfingers: NSPanGestureRecognizer!
     var swipeItems: [SwipeItem] = []
+    var items: [NSTouchBarItem] = []
     var prevPositions: [Int: CGFloat] = [2:0, 3:0, 4:0]
     
     // legacy gesture positions
@@ -25,6 +26,7 @@ class BasicView: NSCustomTouchBarItem, NSGestureRecognizerDelegate {
     init(identifier: NSTouchBarItem.Identifier, items: [NSTouchBarItem], swipeItems: [SwipeItem]) {
         super.init(identifier: identifier)
         self.swipeItems = swipeItems
+        self.items = items
         let views = items.compactMap { $0.view }
         let stackView = NSStackView(views: views)
         stackView.spacing = 1

--- a/MTMR/EventActions.swift
+++ b/MTMR/EventActions.swift
@@ -1,0 +1,184 @@
+//
+//  EventActions.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class EventAction {
+    var closure: ((_ caller: CustomButtonTouchBarItem) -> Void)
+    
+    func setHidKeyClosure(keycode: Int32) -> EventAction {
+        closure = { (_ caller: CustomButtonTouchBarItem) in
+            HIDPostAuxKey(keycode)
+        }
+        return self
+    }
+    
+    func setKeyPressClosure(keycode: Int) -> EventAction {
+        closure = { (_ caller: CustomButtonTouchBarItem) in
+           GenericKeyPress(keyCode: CGKeyCode(keycode)).send()
+        }
+        return self
+    }
+    
+    func setAppleScriptClosure(appleScript: NSAppleScript) -> EventAction {
+        closure = { (_ caller: CustomButtonTouchBarItem) in
+            DispatchQueue.appleScriptQueue.async {
+                var error: NSDictionary?
+                appleScript.executeAndReturnError(&error)
+                if let error = error {
+                    print("error \(error) when handling apple script ")
+                }
+            }
+        }
+        return self
+    }
+    
+    func setShellScriptClosure(executable: String, parameters: [String]) -> EventAction {
+        closure = { (_ caller: CustomButtonTouchBarItem) in
+            let task = Process()
+            task.launchPath = executable
+            task.arguments = parameters
+            task.launch()
+        }
+        return self
+    }
+    
+    func setOpenUrlClosure(url: String) -> EventAction {
+        closure = { (_ caller: CustomButtonTouchBarItem) in
+            if let url = URL(string: url), NSWorkspace.shared.open(url) {
+                #if DEBUG
+                    print("URL was successfully opened")
+                #endif
+            } else {
+                print("error", url)
+            }
+        }
+        return self
+    }
+    
+    init() {
+        self.closure = { (_ caller: CustomButtonTouchBarItem) in }
+    }
+    
+    init(_ closure: @escaping (_ caller: CustomButtonTouchBarItem) -> Void) {
+        self.closure = closure
+    }
+    
+}
+
+class LongTapEventAction: EventAction, Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case longAction
+        case longKeycode
+        case longActionAppleScript
+        case longExecutablePath
+        case longShellArguments
+        case longUrl
+    }
+
+    private enum LongActionTypeRaw: String, Decodable {
+        case hidKey
+        case keyPress
+        case appleScript
+        case shellScript
+        case openUrl
+    }
+    
+    required init(from decoder: Decoder) throws {
+        super.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decodeIfPresent(LongActionTypeRaw.self, forKey: .longAction)
+
+        switch type {
+        case .some(.hidKey):
+            let keycode = try container.decode(Int32.self, forKey: .longKeycode)
+
+            _ = setHidKeyClosure(keycode: keycode)
+        case .some(.keyPress):
+            let keycode = try container.decode(Int.self, forKey: .longKeycode)
+
+            _ = setKeyPressClosure(keycode: keycode)
+        case .some(.appleScript):
+            let source = try container.decode(Source.self, forKey: .longActionAppleScript)
+            
+            guard let appleScript = source.appleScript else {
+                print("cannot create apple script")
+                return
+            }
+            
+            _ = setAppleScriptClosure(appleScript: appleScript)
+        case .some(.shellScript):
+            let executable = try container.decode(String.self, forKey: .longExecutablePath)
+            let parameters = try container.decodeIfPresent([String].self, forKey: .longShellArguments) ?? []
+           
+            _ = setShellScriptClosure(executable: executable, parameters: parameters)
+        case .some(.openUrl):
+            let url = try container.decode(String.self, forKey: .longUrl)
+            
+            _ = setOpenUrlClosure(url: url)
+        case .none:
+            break
+        }
+    }
+}
+
+class SingleTapEventAction: EventAction, Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case action
+        case keycode
+        case actionAppleScript
+        case executablePath
+        case shellArguments
+        case url
+    }
+    
+    private enum ActionTypeRaw: String, Decodable {
+        case hidKey
+        case keyPress
+        case appleScript
+        case shellScript
+        case openUrl
+    }
+    
+    required init(from decoder: Decoder) throws {
+        super.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decodeIfPresent(ActionTypeRaw.self, forKey: .action)
+
+        switch type {
+        case .some(.hidKey):
+            let keycode = try container.decode(Int32.self, forKey: .keycode)
+
+            _ = setHidKeyClosure(keycode: keycode)
+        case .some(.keyPress):
+            let keycode = try container.decode(Int.self, forKey: .keycode)
+
+            _ = setKeyPressClosure(keycode: keycode)
+        case .some(.appleScript):
+            let source = try container.decode(Source.self, forKey: .actionAppleScript)
+            
+            guard let appleScript = source.appleScript else {
+                print("cannot create apple script")
+                return
+            }
+            
+            _ = setAppleScriptClosure(appleScript: appleScript)
+        case .some(.shellScript):
+            let executable = try container.decode(String.self, forKey: .executablePath)
+            let parameters = try container.decodeIfPresent([String].self, forKey: .shellArguments) ?? []
+           
+            _ = setShellScriptClosure(executable: executable, parameters: parameters)
+        case .some(.openUrl):
+            let url = try container.decode(String.self, forKey: .url)
+            
+            _ = setOpenUrlClosure(url: url)
+        case .none:
+            break
+        }
+    }
+}

--- a/MTMR/Info.plist
+++ b/MTMR/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.25</string>
 	<key>CFBundleVersion</key>
-	<string>402</string>
+	<string>622</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MTMR/ItemsParsing.swift
+++ b/MTMR/ItemsParsing.swift
@@ -3,550 +3,90 @@ import Foundation
 
 extension Data {
     func barItemDefinitions() -> [BarItemDefinition]? {
-           return try? JSONDecoder().decode([BarItemDefinition].self, from: utf8string!.stripComments().data(using: .utf8)!)
+        return try? JSONDecoder().decode([BarItemDefinition].self, from: utf8string!.stripComments().data(using: .utf8)!)
     }
 }
 
 struct BarItemDefinition: Decodable {
-    let type: ItemType
-    let action: ActionType
-    let longAction: LongActionType
-    let additionalParameters: [GeneralParameters.CodingKeys: GeneralParameter]
+    let obj: CustomTouchBarItem
+    
+    enum ParsingErrors: Error {
+        case noMatchingType(description: String)
+    }
 
     private enum CodingKeys: String, CodingKey {
-        case type
+        case objtype = "type"
     }
-
-    init(type: ItemType, action: ActionType, longAction: LongActionType, additionalParameters: [GeneralParameters.CodingKeys: GeneralParameter]) {
-        self.type = type
-        self.action = action
-        self.longAction = longAction
-        self.additionalParameters = additionalParameters
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
-        let parametersDecoder = SupportedTypesHolder.sharedInstance.lookup(by: type)
-        var additionalParameters = try GeneralParameters(from: decoder).parameters
-
-        if let result = try? parametersDecoder(decoder),
-            case let (itemType, action, longAction, parameters) = result {
-            parameters.forEach { additionalParameters[$0] = $1 }
-            self.init(type: itemType, action: action, longAction: longAction, additionalParameters: additionalParameters)
-        } else {
-            self.init(type: .staticButton(title: "unknown"), action: .none, longAction: .none, additionalParameters: additionalParameters)
-        }
-    }
-}
-
-typealias ParametersDecoder = (Decoder) throws -> (
-    item: ItemType,
-    action: ActionType,
-    longAction: LongActionType,
-    parameters: [GeneralParameters.CodingKeys: GeneralParameter]
-)
-
-class SupportedTypesHolder {
-    private var supportedTypes: [String: ParametersDecoder] = [
-        "escape": { _ in (
-            item: .staticButton(title: "esc"),
-            action: .keyPress(keycode: 53),
-            longAction: .none,
-            parameters: [.align: .align(.left)]
-        ) },
-
-        "delete": { _ in (
-            item: .staticButton(title: "del"),
-            action: .keyPress(keycode: 117),
-            longAction: .none,
-            parameters: [:]
-        ) },
-
-        "brightnessUp": { _ in
-            let imageParameter = GeneralParameter.image(source: #imageLiteral(resourceName: "brightnessUp"))
-            return (
-                item: .staticButton(title: ""),
-                action: .keyPress(keycode: 144),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "brightnessDown": { _ in
-            let imageParameter = GeneralParameter.image(source: #imageLiteral(resourceName: "brightnessDown"))
-            return (
-                item: .staticButton(title: ""),
-                action: .keyPress(keycode: 145),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "illuminationUp": { _ in
-            let imageParameter = GeneralParameter.image(source: #imageLiteral(resourceName: "ill_up"))
-            return (
-                item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_ILLUMINATION_UP),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "illuminationDown": { _ in
-            let imageParameter = GeneralParameter.image(source: #imageLiteral(resourceName: "ill_down"))
-            return (
-                item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_ILLUMINATION_DOWN),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "volumeDown": { _ in
-            let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarVolumeDownTemplateName)!)
-            return (
-                item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_SOUND_DOWN),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "volumeUp": { _ in
-            let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarVolumeUpTemplateName)!)
-            return (
-                item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_SOUND_UP),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "mute": { _ in
-            let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarAudioOutputMuteTemplateName)!)
-            return (
-                item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_MUTE),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "previous": { _ in
-            let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarRewindTemplateName)!)
-            return (
-                item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_PREVIOUS),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "play": { _ in
-            let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarPlayPauseTemplateName)!)
-            return (
-                item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_PLAY),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "next": { _ in
-            let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarFastForwardTemplateName)!)
-            return (
-                item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_NEXT),
-                longAction: .none,
-                parameters: [.image: imageParameter]
-            )
-        },
-
-        "sleep": { _ in (
-            item: .staticButton(title: "☕️"),
-            action: .shellScript(executable: "/usr/bin/pmset", parameters: ["sleepnow"]),
-            longAction: .none,
-            parameters: [:]
-        ) },
-
-        "displaySleep": { _ in (
-            item: .staticButton(title: "☕️"),
-            action: .shellScript(executable: "/usr/bin/pmset", parameters: ["displaysleepnow"]),
-            longAction: .none,
-            parameters: [:]
-        ) },
-
+    
+    static let types: [CustomTouchBarItem.Type] = [
+        
+        // custom buttons
+        CustomButtonTouchBarItem.self,
+        AppleScriptTouchBarItem.self,
+        ShellScriptTouchBarItem.self,
+        
+        
+        // basic widget buttons
+        EscapeBarItem.self,
+        DeleteBarItem.self,
+        BrightnessUpBarItem.self,
+        BrightnessDownBarItem.self,
+        IlluminationUpBarItem.self,
+        IlluminationDownBarItem.self,
+        VolumeUpBarItem.self,
+        VolumeDownBarItem.self,
+        MuteBarItem.self,
+        PreviousBarItem.self,
+        PlayBarItem.self,
+        NextBarItem.self,
+        SleepBarItem.self,
+        DisplaySleepBarItem.self,
+        
+        
+        // custom widgets
+        TimeTouchBarItem.self,
+        BatteryBarItem.self,
+        AppScrubberTouchBarItem.self,
+        VolumeViewController.self,
+        BrightnessViewController.self,
+        WeatherBarItem.self,
+        YandexWeatherBarItem.self,
+        CurrencyBarItem.self,
+        InputSourceBarItem.self,
+        MusicBarItem.self,
+        NightShiftBarItem.self,
+        DnDBarItem.self,
+        PomodoroBarItem.self,
+        NetworkBarItem.self,
+        DarkModeBarItem.self,
+        
+        
+        // custom-custom objects!
+        SwipeItem.self,
+        GroupBarItem.self,
+        ExitTouchbarBarItem.self,
+        CloseBarItem.self,
     ]
 
-    static let sharedInstance = SupportedTypesHolder()
-
-    func lookup(by type: String) -> ParametersDecoder {
-        return supportedTypes[type] ?? { decoder in (
-            item: try ItemType(from: decoder),
-            action: try ActionType(from: decoder),
-            longAction: try LongActionType(from: decoder),
-            parameters: [:]
-        ) }
-    }
-
-    func register(typename: String, decoder: @escaping ParametersDecoder) {
-        supportedTypes[typename] = decoder
-    }
-
-    func register(typename: String, item: ItemType, action: ActionType, longAction: LongActionType) {
-        register(typename: typename) { _ in
-            (
-                item: item,
-                action,
-                longAction,
-                parameters: [:]
-            )
-        }
-    }
-}
-
-enum ItemType: Decodable {
-    case staticButton(title: String)
-    case appleScriptTitledButton(source: SourceProtocol, refreshInterval: Double, alternativeImages: [String: SourceProtocol])
-    case shellScriptTitledButton(source: SourceProtocol, refreshInterval: Double)
-    case timeButton(formatTemplate: String, timeZone: String?, locale: String?)
-    case battery
-    case dock(autoResize: Bool, filter: String?)
-    case volume
-    case brightness(refreshInterval: Double)
-    case weather(interval: Double, units: String, api_key: String, icon_type: String)
-    case yandexWeather(interval: Double)
-    case currency(interval: Double, from: String, to: String, full: Bool)
-    case inputsource
-    case music(interval: Double, disableMarquee: Bool)
-    case group(items: [BarItemDefinition])
-    case nightShift
-    case dnd
-    case pomodoro(workTime: Double, restTime: Double)
-    case network(flip: Bool)
-    case darkMode
-    case swipe(direction: String, fingers: Int, minOffset: Float, sourceApple: SourceProtocol?, sourceBash: SourceProtocol?)
-
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case title
-        case source
-        case refreshInterval
-        case from
-        case to
-        case full
-        case timeZone
-        case units
-        case api_key
-        case icon_type
-        case formatTemplate
-        case locale
-        case image
-        case url
-        case longUrl
-        case items
-        case workTime
-        case restTime
-        case flip
-        case autoResize
-        case filter
-        case disableMarquee
-        case alternativeImages
-        case sourceApple
-        case sourceBash
-        case direction
-        case fingers
-        case minOffset
-    }
-
-    enum ItemTypeRaw: String, Decodable {
-        case staticButton
-        case appleScriptTitledButton
-        case shellScriptTitledButton
-        case timeButton
-        case battery
-        case dock
-        case volume
-        case brightness
-        case weather
-        case yandexWeather
-        case currency
-        case inputsource
-        case music
-        case group
-        case nightShift
-        case dnd
-        case pomodoro
-        case network
-        case darkMode
-        case swipe
+    init(obj: CustomTouchBarItem) {
+        self.obj = obj
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(ItemTypeRaw.self, forKey: .type)
-        switch type {
-        case .appleScriptTitledButton:
-            let source = try container.decode(Source.self, forKey: .source)
-            let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 1800.0
-            let alternativeImages = try container.decodeIfPresent([String: Source].self, forKey: .alternativeImages) ?? [:]
-            self = .appleScriptTitledButton(source: source, refreshInterval: interval, alternativeImages: alternativeImages)
-            
-        case .shellScriptTitledButton:
-            let source = try container.decode(Source.self, forKey: .source)
-            let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 1800.0
-            self = .shellScriptTitledButton(source: source, refreshInterval: interval)
-
-        case .staticButton:
-            let title = try container.decode(String.self, forKey: .title)
-            self = .staticButton(title: title)
-
-        case .timeButton:
-            let template = try container.decodeIfPresent(String.self, forKey: .formatTemplate) ?? "HH:mm"
-            let timeZone = try container.decodeIfPresent(String.self, forKey: .timeZone) ?? nil
-            let locale = try container.decodeIfPresent(String.self, forKey: .locale) ?? nil
-            self = .timeButton(formatTemplate: template, timeZone: timeZone, locale: locale)
-
-        case .battery:
-            self = .battery
-
-        case .dock:
-            let autoResize = try container.decodeIfPresent(Bool.self, forKey: .autoResize) ?? false
-            let filterRegexString = try container.decodeIfPresent(String.self, forKey: .filter)
-            self = .dock(autoResize: autoResize, filter: filterRegexString)
-
-        case .volume:
-            self = .volume
-
-        case .brightness:
-            let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 0.5
-            self = .brightness(refreshInterval: interval)
-
-        case .weather:
-            let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 1800.0
-            let units = try container.decodeIfPresent(String.self, forKey: .units) ?? "metric"
-            let api_key = try container.decodeIfPresent(String.self, forKey: .api_key) ?? "32c4256d09a4c52b38aecddba7a078f6"
-            let icon_type = try container.decodeIfPresent(String.self, forKey: .icon_type) ?? "text"
-            self = .weather(interval: interval, units: units, api_key: api_key, icon_type: icon_type)
-            
-        case .yandexWeather:
-            let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 1800.0
-            self = .yandexWeather(interval: interval)
-
-        case .currency:
-            let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 600.0
-            let from = try container.decodeIfPresent(String.self, forKey: .from) ?? "RUB"
-            let to = try container.decodeIfPresent(String.self, forKey: .to) ?? "USD"
-            let full = try container.decodeIfPresent(Bool.self, forKey: .full) ?? false
-            self = .currency(interval: interval, from: from, to: to, full: full)
-
-        case .inputsource:
-            self = .inputsource
-
-        case .music:
-            let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 5.0
-            let disableMarquee = try container.decodeIfPresent(Bool.self, forKey: .disableMarquee) ?? false
-            self = .music(interval: interval, disableMarquee: disableMarquee)
-
-        case .group:
-            let items = try container.decode([BarItemDefinition].self, forKey: .items)
-            self = .group(items: items)
-
-        case .nightShift:
-            self = .nightShift
-
-        case .dnd:
-            self = .dnd
-
-        case .pomodoro:
-            let workTime = try container.decodeIfPresent(Double.self, forKey: .workTime) ?? 1500.0
-            let restTime = try container.decodeIfPresent(Double.self, forKey: .restTime) ?? 600.0
-            self = .pomodoro(workTime: workTime, restTime: restTime)
-
-        case .network:
-            let flip = try container.decodeIfPresent(Bool.self, forKey: .flip) ?? false
-            self = .network(flip: flip)
-
-        case .darkMode:
-            self = .darkMode
-            
-        case .swipe:
-            let sourceApple = try container.decodeIfPresent(Source.self, forKey: .sourceApple)
-            let sourceBash = try container.decodeIfPresent(Source.self, forKey: .sourceBash)
-            let direction = try container.decode(String.self, forKey: .direction)
-            let fingers = try container.decode(Int.self, forKey: .fingers)
-            let minOffset = try container.decodeIfPresent(Float.self, forKey: .minOffset) ?? 0.0
-            self = .swipe(direction: direction, fingers: fingers, minOffset: minOffset, sourceApple: sourceApple, sourceBash: sourceBash)
+        let objType = try container.decode(String.self, forKey: .objtype)
+        
+        
+        for obj in BarItemDefinition.types {
+            if obj.typeIdentifier == objType {
+                self.obj = try obj.init(from: decoder)
+                return
+            }
         }
-    }
-}
-
-enum ActionType: Decodable {
-    case none
-    case hidKey(keycode: Int32)
-    case keyPress(keycode: Int)
-    case appleScript(source: SourceProtocol)
-    case shellScript(executable: String, parameters: [String])
-    case custom(closure: () -> Void)
-    case openUrl(url: String)
-
-    private enum CodingKeys: String, CodingKey {
-        case action
-        case keycode
-        case actionAppleScript
-        case executablePath
-        case shellArguments
-        case url
-    }
-
-    private enum ActionTypeRaw: String, Decodable {
-        case hidKey
-        case keyPress
-        case appleScript
-        case shellScript
-        case openUrl
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decodeIfPresent(ActionTypeRaw.self, forKey: .action)
-
-        switch type {
-        case .some(.hidKey):
-            let keycode = try container.decode(Int32.self, forKey: .keycode)
-            self = .hidKey(keycode: keycode)
-
-        case .some(.keyPress):
-            let keycode = try container.decode(Int.self, forKey: .keycode)
-            self = .keyPress(keycode: keycode)
-
-        case .some(.appleScript):
-            let source = try container.decode(Source.self, forKey: .actionAppleScript)
-            self = .appleScript(source: source)
-
-        case .some(.shellScript):
-            let executable = try container.decode(String.self, forKey: .executablePath)
-            let parameters = try container.decodeIfPresent([String].self, forKey: .shellArguments) ?? []
-            self = .shellScript(executable: executable, parameters: parameters)
-
-        case .some(.openUrl):
-            let url = try container.decode(String.self, forKey: .url)
-            self = .openUrl(url: url)
-
-        case .none:
-            self = .none
-        }
-    }
-}
-
-enum LongActionType: Decodable {
-    case none
-    case hidKey(keycode: Int32)
-    case keyPress(keycode: Int)
-    case appleScript(source: SourceProtocol)
-    case shellScript(executable: String, parameters: [String])
-    case custom(closure: () -> Void)
-    case openUrl(url: String)
-
-    private enum CodingKeys: String, CodingKey {
-        case longAction
-        case longKeycode
-        case longActionAppleScript
-        case longExecutablePath
-        case longShellArguments
-        case longUrl
-    }
-
-    private enum LongActionTypeRaw: String, Decodable {
-        case hidKey
-        case keyPress
-        case appleScript
-        case shellScript
-        case openUrl
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let longType = try container.decodeIfPresent(LongActionTypeRaw.self, forKey: .longAction)
-
-        switch longType {
-        case .some(.hidKey):
-            let keycode = try container.decode(Int32.self, forKey: .longKeycode)
-            self = .hidKey(keycode: keycode)
-
-        case .some(.keyPress):
-            let keycode = try container.decode(Int.self, forKey: .longKeycode)
-            self = .keyPress(keycode: keycode)
-
-        case .some(.appleScript):
-            let source = try container.decode(Source.self, forKey: .longActionAppleScript)
-            self = .appleScript(source: source)
-
-        case .some(.shellScript):
-            let executable = try container.decode(String.self, forKey: .longExecutablePath)
-            let parameters = try container.decodeIfPresent([String].self, forKey: .longShellArguments) ?? []
-            self = .shellScript(executable: executable, parameters: parameters)
-
-        case .some(.openUrl):
-            let longUrl = try container.decode(String.self, forKey: .longUrl)
-            self = .openUrl(url: longUrl)
-
-        case .none:
-            self = .none
-        }
-    }
-}
-
-enum GeneralParameter {
-    case width(_: CGFloat)
-    case image(source: SourceProtocol)
-    case align(_: Align)
-    case bordered(_: Bool)
-    case background(_: NSColor)
-    case title(_: String)
-}
-
-struct GeneralParameters: Decodable {
-    let parameters: [GeneralParameters.CodingKeys: GeneralParameter]
-
-    enum CodingKeys: String, CodingKey {
-        case width
-        case image
-        case align
-        case bordered
-        case background
-        case title
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        var result: [GeneralParameters.CodingKeys: GeneralParameter] = [:]
-
-        if let value = try container.decodeIfPresent(CGFloat.self, forKey: .width) {
-            result[.width] = .width(value)
-        }
-
-        if let imageSource = try container.decodeIfPresent(Source.self, forKey: .image) {
-            result[.image] = .image(source: imageSource)
-        }
-
-        let align = try container.decodeIfPresent(Align.self, forKey: .align) ?? .center
-        result[.align] = .align(align)
-
-        if let borderedFlag = try container.decodeIfPresent(Bool.self, forKey: .bordered) {
-            result[.bordered] = .bordered(borderedFlag)
-        }
-
-        if let backgroundColor = try container.decodeIfPresent(String.self, forKey: .background)?.hexColor {
-            result[.background] = .background(backgroundColor)
-        }
-
-        if let title = try container.decodeIfPresent(String.self, forKey: .title) {
-            result[.title] = .title(title)
-        }
-
-        parameters = result
+        
+        
+        print("Cannot find preset mapping for \(objType)")
+        throw ParsingErrors.noMatchingType(description: "Cannot find preset mapping for \(objType)")
     }
 }
 
@@ -644,12 +184,6 @@ extension Data {
     var image: NSImage? {
         return NSImage(data: self)?.resize(maxSize: NSSize(width: 24, height: 24))
     }
-}
-
-enum Align: String, Decodable {
-    case left
-    case center
-    case right
 }
 
 extension URL {

--- a/MTMR/ItemsParsing.swift
+++ b/MTMR/ItemsParsing.swift
@@ -208,7 +208,7 @@ class SupportedTypesHolder {
 
 enum ItemType: Decodable {
     case staticButton(title: String)
-    case appleScriptTitledButton(source: SourceProtocol, refreshInterval: Double)
+    case appleScriptTitledButton(source: SourceProtocol, refreshInterval: Double, alternativeImages: [String: SourceProtocol])
     case shellScriptTitledButton(source: SourceProtocol, refreshInterval: Double)
     case timeButton(formatTemplate: String, timeZone: String?, locale: String?)
     case battery
@@ -251,6 +251,7 @@ enum ItemType: Decodable {
         case autoResize
         case filter
         case disableMarquee
+        case alternativeImages
     }
 
     enum ItemTypeRaw: String, Decodable {
@@ -282,7 +283,8 @@ enum ItemType: Decodable {
         case .appleScriptTitledButton:
             let source = try container.decode(Source.self, forKey: .source)
             let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 1800.0
-            self = .appleScriptTitledButton(source: source, refreshInterval: interval)
+            let alternativeImages = try container.decodeIfPresent([String: Source].self, forKey: .alternativeImages) ?? [:]
+            self = .appleScriptTitledButton(source: source, refreshInterval: interval, alternativeImages: alternativeImages)
             
         case .shellScriptTitledButton:
             let source = try container.decode(Source.self, forKey: .source)

--- a/MTMR/SwipeItem.swift
+++ b/MTMR/SwipeItem.swift
@@ -9,12 +9,25 @@
 import Foundation
 import Foundation
 
-class SwipeItem: NSCustomTouchBarItem {
+class SwipeItem: CustomTouchBarItem {
     private var scriptApple: NSAppleScript?
     private var scriptBash: String?
     private var direction: String
     private var fingers: Int
     private var minOffset: Float
+    
+    private enum CodingKeys: String, CodingKey {
+        case sourceApple
+        case sourceBash
+        case direction
+        case fingers
+        case minOffset
+    }
+    
+    override class var typeIdentifier: String {
+        return "swipe"
+    }
+    
     init?(identifier: NSTouchBarItem.Identifier, direction: String, fingers: Int, minOffset: Float, sourceApple: SourceProtocol?, sourceBash: SourceProtocol?) {
         self.direction = direction
         self.fingers = fingers
@@ -26,6 +39,19 @@ class SwipeItem: NSCustomTouchBarItem {
     
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.scriptApple = try container.decodeIfPresent(Source.self, forKey: .sourceApple)?.appleScript
+        self.scriptBash = try container.decodeIfPresent(Source.self, forKey: .sourceBash)?.string
+        self.direction = try container.decode(String.self, forKey: .direction)
+        self.fingers = try container.decode(Int.self, forKey: .fingers)
+        self.minOffset = try container.decodeIfPresent(Float.self, forKey: .minOffset) ?? 0.0
+        
+        
+        try super.init(from: decoder)
     }
     
     func processEvent(offset: CGFloat, fingers: Int) {

--- a/MTMR/TouchBarController.swift
+++ b/MTMR/TouchBarController.swift
@@ -240,8 +240,8 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
         switch item.type {
         case let .staticButton(title: title):
             barItem = CustomButtonTouchBarItem(identifier: identifier, title: title)
-        case let .appleScriptTitledButton(source: source, refreshInterval: interval):
-            barItem = AppleScriptTouchBarItem(identifier: identifier, source: source, interval: interval)
+        case let .appleScriptTitledButton(source: source, refreshInterval: interval, alternativeImages: alternativeImages):
+            barItem = AppleScriptTouchBarItem(identifier: identifier, source: source, interval: interval, alternativeImages: alternativeImages)
         case let .shellScriptTitledButton(source: source, refreshInterval: interval):
             barItem = ShellScriptTouchBarItem(identifier: identifier, source: source, interval: interval)
         case let .timeButton(formatTemplate: template, timeZone: timeZone, locale: locale):

--- a/MTMR/TouchBarController.swift
+++ b/MTMR/TouchBarController.swift
@@ -16,52 +16,6 @@ struct ExactItem {
 let appSupportDirectory = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!.appending("/MTMR")
 let standardConfigPath = appSupportDirectory.appending("/items.json")
 
-extension ItemType {
-    var identifierBase: String {
-        switch self {
-        case .staticButton(title: _):
-            return "com.toxblh.mtmr.staticButton."
-        case .appleScriptTitledButton(source: _):
-            return "com.toxblh.mtmr.appleScriptButton."
-        case .shellScriptTitledButton(source: _):
-            return "com.toxblh.mtmr.shellScriptButton."
-        case .timeButton(formatTemplate: _, timeZone: _, locale: _):
-            return "com.toxblh.mtmr.timeButton."
-        case .battery:
-            return "com.toxblh.mtmr.battery."
-        case .dock(autoResize: _, filter: _):
-            return "com.toxblh.mtmr.dock"
-        case .volume:
-            return "com.toxblh.mtmr.volume"
-        case .brightness(refreshInterval: _):
-            return "com.toxblh.mtmr.brightness"
-        case .weather(interval: _, units: _, api_key: _, icon_type: _):
-            return "com.toxblh.mtmr.weather"
-        case .yandexWeather(interval: _):
-            return "com.toxblh.mtmr.yandexWeather"
-        case .currency(interval: _, from: _, to: _, full: _):
-            return "com.toxblh.mtmr.currency"
-        case .inputsource:
-            return "com.toxblh.mtmr.inputsource."
-        case .music(interval: _):
-            return "com.toxblh.mtmr.music."
-        case .group(items: _):
-            return "com.toxblh.mtmr.groupBar."
-        case .nightShift:
-            return "com.toxblh.mtmr.nightShift."
-        case .dnd:
-            return "com.toxblh.mtmr.dnd."
-        case .pomodoro(interval: _):
-            return PomodoroBarItem.identifier
-        case .network(flip: _):
-            return NetworkBarItem.identifier
-        case .darkMode:
-            return DarkModeBarItem.identifier
-        case .swipe(direction: _, fingers: _, minOffset: _, sourceApple: _, sourceBash: _):
-            return "com.toxblh.mtmr.swipe."
-        }
-    }
-}
 
 extension NSTouchBarItem.Identifier {
     static let controlStripItem = NSTouchBarItem.Identifier("com.toxblh.mtmr.controlStrip")
@@ -73,12 +27,7 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
     var touchBar: NSTouchBar!
 
     fileprivate var lastPresetPath = ""
-    var jsonItems: [BarItemDefinition] = []
-    var itemDefinitions: [NSTouchBarItem.Identifier: BarItemDefinition] = [:]
-    var items: [NSTouchBarItem.Identifier: NSTouchBarItem] = [:]
-    var leftIdentifiers: [NSTouchBarItem.Identifier] = []
-    var centerIdentifiers: [NSTouchBarItem.Identifier] = []
-    var rightIdentifiers: [NSTouchBarItem.Identifier] = []
+    var items: [CustomTouchBarItem] = []
     var basicViewIdentifier = NSTouchBarItem.Identifier("com.toxblh.mtmr.scrollView.".appending(UUID().uuidString))
     var basicView: BasicView?
     var swipeItems: [SwipeItem] = []
@@ -90,14 +39,6 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
 
     private override init() {
         super.init()
-        SupportedTypesHolder.sharedInstance.register(typename: "exitTouchbar", item: .staticButton(title: "exit"), action: .custom(closure: { [weak self] in self?.dismissTouchBar() }), longAction: .none)
-
-        SupportedTypesHolder.sharedInstance.register(typename: "close") { _ in
-            (item: .staticButton(title: ""), action: .custom(closure: { [weak self] in
-                guard let `self` = self else { return }
-                self.reloadPreset(path: self.lastPresetPath)
-            }), longAction: .none, parameters: [.width: .width(30), .image: .image(source: (NSImage(named: NSImage.stopProgressFreestandingTemplateName))!)])
-        }
 
         blacklistAppIdentifiers = AppSettings.blacklistedAppIds
         
@@ -108,21 +49,23 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
         reloadStandardConfig()
     }
 
-    func createAndUpdatePreset(newJsonItems: [BarItemDefinition]) {
+    func createAndUpdatePreset(newItems: [BarItemDefinition]) {
         if let oldBar = self.touchBar {
             minimizeSystemModal(oldBar)
         }
         touchBar = NSTouchBar()
-        jsonItems = newJsonItems
-        itemDefinitions = [:]
-        items = [:]
+        (items, swipeItems) = getItems(newItems: newItems)
 
-        loadItemDefinitions(jsonItems: jsonItems)
-        createItems()
-
-        let centerItems = centerIdentifiers.compactMap({ (identifier) -> NSTouchBarItem? in
-            items[identifier]
+        let leftItems = items.compactMap({ (item) -> CustomTouchBarItem? in
+            item.align == .left ? item : nil
         })
+        let centerItems = items.compactMap({ (item) -> CustomTouchBarItem? in
+            item.align == .center ? item : nil
+        })
+        let rightItems = items.compactMap({ (item) -> CustomTouchBarItem? in
+            item.align == .right ? item : nil
+        })
+        
         
         let centerScrollArea = NSTouchBarItem.Identifier("com.toxblh.mtmr.scrollArea.".appending(UUID().uuidString))
         let scrollArea = ScrollViewItem(identifier: centerScrollArea, items: centerItems)
@@ -130,15 +73,17 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
         touchBar.delegate = self
         touchBar.defaultItemIdentifiers = [basicViewIdentifier]
         
-        let leftItems = leftIdentifiers.compactMap({ (identifier) -> NSTouchBarItem? in
-            items[identifier]
-        })
-        let rightItems = rightIdentifiers.compactMap({ (identifier) -> NSTouchBarItem? in
-            items[identifier]
-        })
-        
-        basicView = BasicView(identifier: basicViewIdentifier, items:leftItems + [scrollArea] + rightItems, swipeItems: swipeItems)
+        basicView = BasicView(identifier: basicViewIdentifier, items: leftItems + [scrollArea] + rightItems, swipeItems: swipeItems)
         basicView?.legacyGesturesEnabled = AppSettings.multitouchGestures
+        
+        // it seems that we need to set width only after we added them to the view
+        // so lets reset width here
+        for item in items {
+            item.setWidth(value: item.getWidth())
+            if item is CustomButtonTouchBarItem {
+                (item as! CustomButtonTouchBarItem).reinstallButton()
+            }
+        }
 
         updateActiveApp()
     }
@@ -166,41 +111,26 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
         reloadPreset(path: presetPath)
     }
 
-    func reloadPreset(path: String) {
-        lastPresetPath = path
-        let items = path.fileData?.barItemDefinitions() ?? [BarItemDefinition(type: .staticButton(title: "bad preset"), action: .none, longAction: .none, additionalParameters: [:])]
-        createAndUpdatePreset(newJsonItems: items)
-    }
-
-    func loadItemDefinitions(jsonItems: [BarItemDefinition]) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "HH-mm-ss"
-        let time = dateFormatter.string(from: Date())
-        for item in jsonItems {
-            let identifierString = item.type.identifierBase.appending(time + "--" + UUID().uuidString)
-            let identifier = NSTouchBarItem.Identifier(identifierString)
-            itemDefinitions[identifier] = item
-            if item.align == .left {
-                leftIdentifiers.append(identifier)
-            }
-            if item.align == .right {
-                rightIdentifiers.append(identifier)
-            }
-            if item.align == .center {
-                centerIdentifiers.append(identifier)
-            }
+    func reloadPreset(path: String?) {
+        if path != nil {
+            lastPresetPath = path!
         }
+        
+        let items = lastPresetPath.fileData?.barItemDefinitions() ?? [BarItemDefinition(obj: CustomButtonTouchBarItem(title: "bad preset"))]
+        createAndUpdatePreset(newItems: items)
     }
 
-    func createItems() {
-        for (identifier, definition) in itemDefinitions {
-            let item = createItem(forIdentifier: identifier, definition: definition)
-            if item is SwipeItem {
-                swipeItems.append(item as! SwipeItem)
+    func getItems(newItems: [BarItemDefinition]) -> ([CustomTouchBarItem], [SwipeItem]) {
+        var items: [CustomTouchBarItem] = []
+        var swipeItems: [SwipeItem] = []
+        for item in newItems {
+            if item.obj is SwipeItem {
+                swipeItems.append(item.obj as! SwipeItem)
             } else {
-                items[identifier] = item
+                items.append(item.obj)
             }
         }
+        return (items, swipeItems)
     }
 
     @objc func setupControlStripPresence() {
@@ -224,7 +154,7 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
         }
     }
 
-    @objc private func dismissTouchBar() {
+    @objc func dismissTouchBar() {
         minimizeSystemModal(touchBar)
         updateControlStripPresence()
     }
@@ -241,198 +171,8 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
 
         return nil
     }
-
-    func createItem(forIdentifier identifier: NSTouchBarItem.Identifier, definition item: BarItemDefinition) -> NSTouchBarItem? {
-        var barItem: NSTouchBarItem!
-        switch item.type {
-        case let .staticButton(title: title):
-            barItem = CustomButtonTouchBarItem(identifier: identifier, title: title)
-        case let .appleScriptTitledButton(source: source, refreshInterval: interval, alternativeImages: alternativeImages):
-            barItem = AppleScriptTouchBarItem(identifier: identifier, source: source, interval: interval, alternativeImages: alternativeImages)
-        case let .shellScriptTitledButton(source: source, refreshInterval: interval):
-            barItem = ShellScriptTouchBarItem(identifier: identifier, source: source, interval: interval)
-        case let .timeButton(formatTemplate: template, timeZone: timeZone, locale: locale):
-            barItem = TimeTouchBarItem(identifier: identifier, formatTemplate: template, timeZone: timeZone, locale: locale)
-        case .battery:
-            barItem = BatteryBarItem(identifier: identifier)
-        case let .dock(autoResize: autoResize, filter: regexString):
-            if let regexString = regexString {
-                guard let regex = try? NSRegularExpression(pattern: regexString, options: []) else {
-                    barItem = CustomButtonTouchBarItem(identifier: identifier, title: "Bad regex")
-                    break
-                }
-                barItem = AppScrubberTouchBarItem(identifier: identifier, autoResize: autoResize, filter: regex)
-            } else {
-                barItem = AppScrubberTouchBarItem(identifier: identifier, autoResize: autoResize)
-            }
-        case .volume:
-            if case let .image(source)? = item.additionalParameters[.image] {
-                barItem = VolumeViewController(identifier: identifier, image: source.image)
-            } else {
-                barItem = VolumeViewController(identifier: identifier)
-            }
-        case let .brightness(refreshInterval: interval):
-            if case let .image(source)? = item.additionalParameters[.image] {
-                barItem = BrightnessViewController(identifier: identifier, refreshInterval: interval, image: source.image)
-            } else {
-                barItem = BrightnessViewController(identifier: identifier, refreshInterval: interval)
-            }
-        case let .weather(interval: interval, units: units, api_key: api_key, icon_type: icon_type):
-            barItem = WeatherBarItem(identifier: identifier, interval: interval, units: units, api_key: api_key, icon_type: icon_type)
-        case let .yandexWeather(interval: interval):
-            barItem = YandexWeatherBarItem(identifier: identifier, interval: interval)
-        case let .currency(interval: interval, from: from, to: to, full: full):
-            barItem = CurrencyBarItem(identifier: identifier, interval: interval, from: from, to: to, full: full)
-        case .inputsource:
-            barItem = InputSourceBarItem(identifier: identifier)
-        case let .music(interval: interval, disableMarquee: disableMarquee):
-            barItem = MusicBarItem(identifier: identifier, interval: interval, disableMarquee: disableMarquee)
-        case let .group(items: items):
-            barItem = GroupBarItem(identifier: identifier, items: items)
-        case .nightShift:
-            barItem = NightShiftBarItem(identifier: identifier)
-        case .dnd:
-            barItem = DnDBarItem(identifier: identifier)
-        case let .pomodoro(workTime: workTime, restTime: restTime):
-            barItem = PomodoroBarItem(identifier: identifier, workTime: workTime, restTime: restTime)
-        case let .network(flip: flip):
-            barItem = NetworkBarItem(identifier: identifier, flip: flip)
-        case .darkMode:
-            barItem = DarkModeBarItem(identifier: identifier)
-        case let .swipe(direction: direction, fingers: fingers, minOffset: minOffset, sourceApple: sourceApple, sourceBash: sourceBash):
-            barItem = SwipeItem(identifier: identifier, direction: direction, fingers: fingers, minOffset: minOffset, sourceApple: sourceApple, sourceBash: sourceBash)
-        }
-
-        if let action = self.action(forItem: item), let item = barItem as? CustomButtonTouchBarItem {
-            item.tapClosure = action
-        }
-        if let longAction = self.longAction(forItem: item), let item = barItem as? CustomButtonTouchBarItem {
-            item.longTapClosure = longAction
-        }
-        if case let .bordered(bordered)? = item.additionalParameters[.bordered], let item = barItem as? CustomButtonTouchBarItem {
-            item.isBordered = bordered
-        }
-        if case let .background(color)? = item.additionalParameters[.background], let item = barItem as? CustomButtonTouchBarItem {
-            item.backgroundColor = color
-        }
-        if case let .width(value)? = item.additionalParameters[.width], let widthBarItem = barItem as? CanSetWidth {
-            widthBarItem.setWidth(value: value)
-        }
-        if case let .image(source)? = item.additionalParameters[.image], let item = barItem as? CustomButtonTouchBarItem {
-            item.image = source.image
-        }
-        if case let .title(value)? = item.additionalParameters[.title] {
-            if let item = barItem as? GroupBarItem {
-                item.collapsedRepresentationLabel = value
-            } else if let item = barItem as? CustomButtonTouchBarItem {
-                item.title = value
-            }
-        }
-        return barItem
-    }
-
-    func action(forItem item: BarItemDefinition) -> (() -> Void)? {
-        switch item.action {
-        case let .hidKey(keycode: keycode):
-            return { HIDPostAuxKey(keycode) }
-        case let .keyPress(keycode: keycode):
-            return { GenericKeyPress(keyCode: CGKeyCode(keycode)).send() }
-        case let .appleScript(source: source):
-            guard let appleScript = source.appleScript else {
-                print("cannot create apple script for item \(item)")
-                return {}
-            }
-            return {
-                DispatchQueue.appleScriptQueue.async {
-                    var error: NSDictionary?
-                    appleScript.executeAndReturnError(&error)
-                    if let error = error {
-                        print("error \(error) when handling \(item) ")
-                    }
-                }
-            }
-        case let .shellScript(executable: executable, parameters: parameters):
-            return {
-                let task = Process()
-                task.launchPath = executable
-                task.arguments = parameters
-                task.launch()
-            }
-        case let .openUrl(url: url):
-            return {
-                if let url = URL(string: url), NSWorkspace.shared.open(url) {
-                    #if DEBUG
-                        print("URL was successfully opened")
-                    #endif
-                } else {
-                    print("error", url)
-                }
-            }
-        case let .custom(closure: closure):
-            return closure
-        case .none:
-            return nil
-        }
-    }
-
-    func longAction(forItem item: BarItemDefinition) -> (() -> Void)? {
-        switch item.longAction {
-        case let .hidKey(keycode: keycode):
-            return { HIDPostAuxKey(keycode) }
-        case let .keyPress(keycode: keycode):
-            return { GenericKeyPress(keyCode: CGKeyCode(keycode)).send() }
-        case let .appleScript(source: source):
-            guard let appleScript = source.appleScript else {
-                print("cannot create apple script for item \(item)")
-                return {}
-            }
-            return {
-                var error: NSDictionary?
-                appleScript.executeAndReturnError(&error)
-                if let error = error {
-                    print("error \(error) when handling \(item) ")
-                }
-            }
-        case let .shellScript(executable: executable, parameters: parameters):
-            return {
-                let task = Process()
-                task.launchPath = executable
-                task.arguments = parameters
-                task.launch()
-            }
-        case let .openUrl(url: url):
-            return {
-                if let url = URL(string: url), NSWorkspace.shared.open(url) {
-                    #if DEBUG
-                        print("URL was successfully opened")
-                    #endif
-                } else {
-                    print("error", url)
-                }
-            }
-        case let .custom(closure: closure):
-            return closure
-        case .none:
-            return nil
-        }
-    }
 }
 
 protocol CanSetWidth {
     func setWidth(value: CGFloat)
-}
-
-extension NSCustomTouchBarItem: CanSetWidth {
-    func setWidth(value: CGFloat) {
-        view.widthAnchor.constraint(equalToConstant: value).isActive = true
-    }
-}
-
-extension BarItemDefinition {
-    var align: Align {
-        if case let .align(result)? = additionalParameters[.align] {
-            return result
-        }
-        return .center
-    }
 }

--- a/MTMR/Widgets/BatteryBarItem.swift
+++ b/MTMR/Widgets/BatteryBarItem.swift
@@ -12,21 +12,35 @@ import IOKit.ps
 class BatteryBarItem: CustomButtonTouchBarItem {
     private let batteryInfo = BatteryInfo()
 
+    override class var typeIdentifier: String {
+        return "battery"
+    }
+    
     init(identifier: NSTouchBarItem.Identifier) {
         super.init(identifier: identifier, title: " ")
 
+        self.setup()
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setup()
+    }
+    
+    func setup() {
         batteryInfo.start { [weak self] in
             self?.refresh()
         }
         refresh()
     }
 
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     func refresh() {
-        attributedTitle = batteryInfo.formattedInfo()
+        setAttributedTitle(batteryInfo.formattedInfo())
     }
 
     deinit {

--- a/MTMR/Widgets/BrightnessDownBarItem.swift
+++ b/MTMR/Widgets/BrightnessDownBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  BrightnessDownBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class BrightnessDownBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "brightnessDown"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(#imageLiteral(resourceName: "brightnessDown"))
+        self.setTapAction(EventAction().setKeyPressClosure(keycode: 145))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/BrightnessUpBarItem.swift
+++ b/MTMR/Widgets/BrightnessUpBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  BrightnessUpBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class BrightnessUpBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "brightnessUp"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(#imageLiteral(resourceName: "brightnessUp"))
+        self.setTapAction(EventAction().setKeyPressClosure(keycode: 144))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/BrightnessViewController.swift
+++ b/MTMR/Widgets/BrightnessViewController.swift
@@ -3,12 +3,39 @@ import AVFoundation
 import Cocoa
 import CoreAudio
 
-class BrightnessViewController: NSCustomTouchBarItem {
+class BrightnessViewController: CustomTouchBarItem {
     private(set) var sliderItem: CustomSlider!
 
+    override class var typeIdentifier: String {
+        return "brightness"
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case image
+        case refreshInterval
+    }
+    
     init(identifier: NSTouchBarItem.Identifier, refreshInterval: Double, image: NSImage? = nil) {
         super.init(identifier: identifier)
+        self.setup(image: nil, interval: refreshInterval)
+    }
 
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let image = try container.decodeIfPresent(Source.self, forKey: .image)?.image
+        let interval = try container.decodeIfPresent(Double.self, forKey: .refreshInterval) ?? 0.5
+        
+        try super.init(from: decoder)
+
+        self.setup(image: image, interval: interval)
+    }
+    
+    
+    func setup(image: NSImage?, interval: Double) {
         if image == nil {
             sliderItem = CustomSlider()
         } else {
@@ -22,12 +49,8 @@ class BrightnessViewController: NSCustomTouchBarItem {
 
         view = sliderItem
 
-        let timer = Timer.scheduledTimer(timeInterval: refreshInterval, target: self, selector: #selector(BrightnessViewController.updateBrightnessSlider), userInfo: nil, repeats: true)
+        let timer = Timer.scheduledTimer(timeInterval: interval, target: self, selector: #selector(BrightnessViewController.updateBrightnessSlider), userInfo: nil, repeats: true)
         RunLoop.current.add(timer, forMode: RunLoop.Mode.common)
-    }
-
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 
     deinit {

--- a/MTMR/Widgets/CloseBarItem.swift
+++ b/MTMR/Widgets/CloseBarItem.swift
@@ -1,0 +1,48 @@
+//
+//  CloseBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/30/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class CloseBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "close"
+    }
+    
+    init(identifier: NSTouchBarItem.Identifier) {
+        super.init(identifier: identifier, title: "")
+        
+        if self.title == "" {
+            self.title = "close"
+        }
+        
+        self.setTapAction(EventAction.init({_ in
+            
+            TouchBarController.shared.reloadPreset(path: nil)
+            
+        } ))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        if self.title == "" {
+            self.title = "close"
+        }
+        
+        self.setTapAction(EventAction.init({_ in
+            
+            TouchBarController.shared.reloadPreset(path: nil)
+            
+        } ))
+    }
+    
+}

--- a/MTMR/Widgets/DarkModeBarItem.swift
+++ b/MTMR/Widgets/DarkModeBarItem.swift
@@ -1,25 +1,42 @@
 import Foundation
 
-class DarkModeBarItem: CustomButtonTouchBarItem, Widget {
-    static var name: String = "darkmode"
-    static var identifier: String = "com.toxblh.mtmr.darkmode"
-
+class DarkModeBarItem: CustomButtonTouchBarItem {
     private var timer: Timer!
+    
+    override class var typeIdentifier: String {
+        return "darkMode"
+    }
 
     init(identifier: NSTouchBarItem.Identifier) {
         super.init(identifier: identifier, title: "")
-        isBordered = false
-        setWidth(value: 24)
-
-        tapClosure = { [weak self] in self?.DarkModeToggle() }
-
-        timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
-
-        refresh()
+        
+        self.setup()
     }
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setup()
+    }
+    
+    func setup() {
+        if getWidth() == 0.0 {
+            setWidth(value: 24)
+        }
+
+        self.setTapAction(
+            EventAction({ [weak self] (_ caller: CustomButtonTouchBarItem) in
+                self?.DarkModeToggle()
+            } )
+        )
+
+        timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
+
+        refresh()
     }
 
     func DarkModeToggle() {
@@ -28,7 +45,7 @@ class DarkModeBarItem: CustomButtonTouchBarItem, Widget {
     }
 
     @objc func refresh() {
-        image = DarkMode.isEnabled ? #imageLiteral(resourceName: "dark-mode-on") : #imageLiteral(resourceName: "dark-mode-off")
+        self.setImage(DarkMode.isEnabled ? #imageLiteral(resourceName: "dark-mode-on") : #imageLiteral(resourceName: "dark-mode-off"))
     }
 }
 

--- a/MTMR/Widgets/DeleteBarItem.swift
+++ b/MTMR/Widgets/DeleteBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  DeleteBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class DeleteBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "delete"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        print("DeleteBarItem.init")
+        self.title = "del"
+        self.setTapAction(EventAction().setKeyPressClosure(keycode: 117))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/MTMR/Widgets/DisplaySleepBarItem.swift
+++ b/MTMR/Widgets/DisplaySleepBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  DisplaySleep.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class DisplaySleepBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "displaySleep"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.title = "☕️"
+        self.setTapAction(EventAction().setShellScriptClosure(executable: "/usr/bin/pmset", parameters: ["displaysleepnow"]))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/DnDBarItem.swift
+++ b/MTMR/Widgets/DnDBarItem.swift
@@ -11,20 +11,38 @@ import Foundation
 class DnDBarItem: CustomButtonTouchBarItem {
     private var timer: Timer!
 
+    override class var typeIdentifier: String {
+        return "dnd"
+    }
+    
     init(identifier: NSTouchBarItem.Identifier) {
         super.init(identifier: identifier, title: "")
-        isBordered = false
-        setWidth(value: 32)
-
-        tapClosure = { [weak self] in self?.DnDToggle() }
-
-        timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
-
-        refresh()
+        self.setup()
     }
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        self.setup()
+    }
+    
+    func setup() {
+        if getWidth() == 0.0 {
+            setWidth(value: 32)
+        }
+
+        self.setTapAction(
+            EventAction({ [weak self] (_ caller: CustomButtonTouchBarItem) in
+                self?.DnDToggle()
+            } )
+        )
+
+        timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
+
+        refresh()
     }
 
     func DnDToggle() {
@@ -33,7 +51,7 @@ class DnDBarItem: CustomButtonTouchBarItem {
     }
 
     @objc func refresh() {
-        image = DoNotDisturb.isEnabled ? #imageLiteral(resourceName: "dnd-on") : #imageLiteral(resourceName: "dnd-off")
+        self.setImage(DoNotDisturb.isEnabled ? #imageLiteral(resourceName: "dnd-on") : #imageLiteral(resourceName: "dnd-off"))
     }
 }
 

--- a/MTMR/Widgets/EscapeBarItem.swift
+++ b/MTMR/Widgets/EscapeBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  EscapeBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class EscapeBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "escape"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.title = "escape"
+        self.setTapAction(EventAction().setKeyPressClosure(keycode: 53))
+        self.align = .left
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/MTMR/Widgets/ExitTouchbarBarItem.swift
+++ b/MTMR/Widgets/ExitTouchbarBarItem.swift
@@ -1,0 +1,50 @@
+//
+//  ExitTouchbarBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/30/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class ExitTouchbarBarItem: CustomButtonTouchBarItem {
+    private var timer: Timer!
+    
+    override class var typeIdentifier: String {
+        return "exitTouchbar"
+    }
+
+    init(identifier: NSTouchBarItem.Identifier) {
+        super.init(identifier: identifier, title: "")
+        
+        if self.title == "" {
+            self.title = "exit"
+        }
+        
+        self.setTapAction(EventAction.init({_ in
+            
+            TouchBarController.shared.dismissTouchBar()
+            
+        } ))
+    }
+    
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        if self.title == "" {
+            self.title = "exit"
+        }
+        
+        self.setTapAction(EventAction.init({_ in
+            
+            TouchBarController.shared.dismissTouchBar()
+            
+        } ))
+    }
+    
+}

--- a/MTMR/Widgets/IlluminationDownBarItem.swift
+++ b/MTMR/Widgets/IlluminationDownBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  illuminationDownBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class IlluminationDownBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "illuminationDown"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(#imageLiteral(resourceName: "ill_down"))
+        self.setTapAction(EventAction().setHidKeyClosure(keycode: NX_KEYTYPE_ILLUMINATION_DOWN))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/IlluminationUpBarItem.swift
+++ b/MTMR/Widgets/IlluminationUpBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  illuminationUpBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class IlluminationUpBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "illuminationUp"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(#imageLiteral(resourceName: "ill_up"))
+        self.setTapAction(EventAction().setHidKeyClosure(keycode: NX_KEYTYPE_ILLUMINATION_UP))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/InputSourceBarItem.swift
+++ b/MTMR/Widgets/InputSourceBarItem.swift
@@ -11,22 +11,39 @@ import Cocoa
 class InputSourceBarItem: CustomButtonTouchBarItem {
     fileprivate var notificationCenter: CFNotificationCenter
     let buttonSize = NSSize(width: 21, height: 21)
+    
+    override class var typeIdentifier: String {
+        return "inputsource"
+    }
 
     init(identifier: NSTouchBarItem.Identifier) {
         notificationCenter = CFNotificationCenterGetDistributedCenter()
         super.init(identifier: identifier, title: "⏳")
-
-        observeIputSourceChangedNotification()
-        textInputSourceDidChange()
-        tapClosure = { [weak self] in
-            self?.switchInputSource()
-        }
+        
+        self.setup()
     }
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    required init(from decoder: Decoder) throws {
+        notificationCenter = CFNotificationCenterGetDistributedCenter()
+        try super.init(from: decoder)
+        
+        self.setup()
+    }
 
+    func setup() {
+        observeIputSourceChangedNotification()
+        textInputSourceDidChange()
+        self.setTapAction(
+            EventAction({ [weak self] (_ caller: CustomButtonTouchBarItem) in
+                self?.switchInputSource()
+            }
+        ))
+    }
+    
     deinit {
         CFNotificationCenterRemoveEveryObserver(notificationCenter, UnsafeRawPointer(Unmanaged.passUnretained(self).toOpaque()))
     }
@@ -45,7 +62,7 @@ class InputSourceBarItem: CustomButtonTouchBarItem {
 
         if let iconImage = iconImage {
             iconImage.size = buttonSize
-            image = iconImage
+            self.setImage(iconImage)
             title = ""
         } else {
             title = currentSource.name

--- a/MTMR/Widgets/MuteBarItem.swift
+++ b/MTMR/Widgets/MuteBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  MuteBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class MuteBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "mute"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(NSImage(named: NSImage.touchBarAudioOutputMuteTemplateName)!)
+        self.setTapAction(EventAction().setHidKeyClosure(keycode: NX_KEYTYPE_MUTE))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/NetworkBarItem.swift
+++ b/MTMR/Widgets/NetworkBarItem.swift
@@ -8,11 +8,16 @@
 
 import Foundation
 
-class NetworkBarItem: CustomButtonTouchBarItem, Widget {
-    static var name: String = "network"
-    static var identifier: String = "com.toxblh.mtmr.network"
-    
+class NetworkBarItem: CustomButtonTouchBarItem {    
     private let flip: Bool
+    
+    private enum CodingKeys: String, CodingKey {
+        case flip
+    }
+    
+    override class var typeIdentifier: String {
+        return "network"
+    }
     
     init(identifier: NSTouchBarItem.Identifier, flip: Bool = false) {
         self.flip = flip
@@ -22,6 +27,14 @@ class NetworkBarItem: CustomButtonTouchBarItem, Widget {
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.flip = try container.decodeIfPresent(Bool.self, forKey: .flip) ?? false
+        
+        try super.init(from: decoder)
+        startMonitoringProcess()
     }
 
     func startMonitoringProcess() {
@@ -144,6 +157,6 @@ class NetworkBarItem: CustomButtonTouchBarItem, Widget {
         }
         
         
-        self.attributedTitle = newTitle
+        self.setAttributedTitle(newTitle)
     }
 }

--- a/MTMR/Widgets/NextBarItem.swift
+++ b/MTMR/Widgets/NextBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  NextBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class NextBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "next"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(NSImage(named: NSImage.touchBarFastForwardTemplateName)!)
+        self.setTapAction(EventAction().setHidKeyClosure(keycode: NX_KEYTYPE_NEXT))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/NightShiftBarItem.swift
+++ b/MTMR/Widgets/NightShiftBarItem.swift
@@ -11,6 +11,10 @@ import Foundation
 class NightShiftBarItem: CustomButtonTouchBarItem {
     private let nsclient = CBBlueLightClient()
     private var timer: Timer!
+    
+    override class var typeIdentifier: String {
+        return "nightShift"
+    }
 
     private var blueLightStatus: Status {
         var status: Status = Status()
@@ -28,18 +32,32 @@ class NightShiftBarItem: CustomButtonTouchBarItem {
 
     init(identifier: NSTouchBarItem.Identifier) {
         super.init(identifier: identifier, title: "")
-        isBordered = false
-        setWidth(value: 28)
-
-        tapClosure = { [weak self] in self?.nightShiftAction() }
-
-        timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
-
-        refresh()
+        self.setup()
     }
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        self.setup()
+    }
+    
+    func setup() {
+        if getWidth() == 0.0 {
+            setWidth(value: 28)
+        }
+
+        self.setTapAction(
+            EventAction( { [weak self] (_ caller: CustomButtonTouchBarItem) in
+                self?.nightShiftAction()
+            } )
+        )
+
+        timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
+
+        refresh()
     }
 
     func nightShiftAction() {
@@ -48,6 +66,6 @@ class NightShiftBarItem: CustomButtonTouchBarItem {
     }
 
     @objc func refresh() {
-        image = isNightShiftEnabled ? #imageLiteral(resourceName: "nightShiftOn") : #imageLiteral(resourceName: "nightShiftOff")
+        self.setImage(isNightShiftEnabled ? #imageLiteral(resourceName: "nightShiftOn") : #imageLiteral(resourceName: "nightShiftOff"))
     }
 }

--- a/MTMR/Widgets/PlayBarItem.swift
+++ b/MTMR/Widgets/PlayBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  PlayBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class PlayBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "play"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(NSImage(named: NSImage.touchBarPlayPauseTemplateName)!)
+        self.setTapAction(EventAction().setHidKeyClosure(keycode: NX_KEYTYPE_PLAY))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/PreviousBarItem.swift
+++ b/MTMR/Widgets/PreviousBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  PreviousBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class PreviousBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "previous"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(NSImage(named: NSImage.touchBarRewindTemplateName)!)
+        self.setTapAction(EventAction().setHidKeyClosure(keycode: NX_KEYTYPE_PREVIOUS))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/SleepBarItem.swift
+++ b/MTMR/Widgets/SleepBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  SleepBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class SleepBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "sleep"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.title = "☕️"
+        self.setTapAction(EventAction().setShellScriptClosure(executable: "/usr/bin/pmset", parameters: ["sleepnow"]))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/TimeTouchBarItem.swift
+++ b/MTMR/Widgets/TimeTouchBarItem.swift
@@ -4,7 +4,40 @@ class TimeTouchBarItem: CustomButtonTouchBarItem {
     private let dateFormatter = DateFormatter()
     private var timer: Timer!
 
+    private enum CodingKeys: String, CodingKey {
+        case formatTemplate
+        case timeZone
+        case locale
+    }
+    
+    override class var typeIdentifier: String {
+        return "timeButton"
+    }
+    
     init(identifier: NSTouchBarItem.Identifier, formatTemplate: String, timeZone: String? = nil, locale: String? = nil) {
+        super.init(identifier: identifier, title: " ")
+        self.setupFormatter(formatTemplate: formatTemplate, timeZone: timeZone, locale: locale)
+        self.setupTimer()
+        updateTime()
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let template = try container.decodeIfPresent(String.self, forKey: .formatTemplate) ?? "HH:mm"
+        let timeZone = try container.decodeIfPresent(String.self, forKey: .timeZone) ?? nil
+        let locale = try container.decodeIfPresent(String.self, forKey: .locale) ?? nil
+       
+        try super.init(from: decoder)
+        self.setupFormatter(formatTemplate: template, timeZone: timeZone, locale: locale)
+        self.setupTimer()
+        updateTime()
+   }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupFormatter(formatTemplate: String, timeZone: String? = nil, locale: String? = nil) {
         dateFormatter.dateFormat = formatTemplate
         if let locale = locale {
             dateFormatter.locale = Locale(identifier: locale)
@@ -12,14 +45,10 @@ class TimeTouchBarItem: CustomButtonTouchBarItem {
         if let abbr = timeZone {
             dateFormatter.timeZone = TimeZone(abbreviation: abbr)
         }
-        super.init(identifier: identifier, title: " ")
-        timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(updateTime), userInfo: nil, repeats: true)
-        isBordered = false
-        updateTime()
     }
-
-    required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    
+    func setupTimer() {
+        timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(updateTime), userInfo: nil, repeats: true)
     }
 
     @objc func updateTime() {

--- a/MTMR/Widgets/VolumeDownBarItem.swift
+++ b/MTMR/Widgets/VolumeDownBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  volumeDownBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class VolumeDownBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "volumeDown"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(NSImage(named: NSImage.touchBarVolumeDownTemplateName)!)
+        self.setTapAction(EventAction().setHidKeyClosure(keycode: NX_KEYTYPE_SOUND_DOWN))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/VolumeUpBarItem.swift
+++ b/MTMR/Widgets/VolumeUpBarItem.swift
@@ -1,0 +1,27 @@
+//
+//  VolumeUpBarItem.swift
+//  MTMR
+//
+//  Created by Fedor Zaitsev on 4/27/20.
+//  Copyright © 2020 Anton Palgunov. All rights reserved.
+//
+
+import Foundation
+
+class VolumeUpBarItem: CustomButtonTouchBarItem {
+    override class var typeIdentifier: String {
+        return "volumeUp"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        
+        self.setImage(NSImage(named: NSImage.touchBarVolumeUpTemplateName)!)
+        self.setTapAction(EventAction().setHidKeyClosure(keycode: NX_KEYTYPE_SOUND_UP))
+    }
+
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MTMR/Widgets/VolumeViewController.swift
+++ b/MTMR/Widgets/VolumeViewController.swift
@@ -3,12 +3,33 @@ import AVFoundation
 import Cocoa
 import CoreAudio
 
-class VolumeViewController: NSCustomTouchBarItem {
+class VolumeViewController: CustomTouchBarItem {
     private(set) var sliderItem: CustomSlider!
+    
+    override class var typeIdentifier: String {
+        return "volume"
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case image
+    }
 
     init(identifier: NSTouchBarItem.Identifier, image: NSImage? = nil) {
         super.init(identifier: identifier)
 
+        self.setup(image: image)
+    }
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let image = try container.decodeIfPresent(Source.self, forKey: .image)?.image
+        
+        try super.init(from: decoder)
+
+        self.setup(image: image)
+    }
+    
+    func setup(image: NSImage?) {
         var forPropertyAddress = AudioObjectPropertyAddress(
             mSelector: kAudioHardwareServiceDeviceProperty_VirtualMasterVolume,
             mScope: kAudioDevicePropertyScopeOutput,
@@ -36,6 +57,7 @@ class VolumeViewController: NSCustomTouchBarItem {
             self.sliderItem.floatValue = self.getInputGain() * 100
         }
     }
+    
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/README.md
+++ b/README.md
@@ -133,8 +133,35 @@ The pre-installed configuration contains less or more than you'll probably want,
       "inline": "tell application \"Finder\"\rif not (exists window 1) then\rmake new Finder window\rset target of front window to path to home folder as string\rend if\ractivate\rend tell",
       // or
       "base64": "StringInbase64"
-    }
+    },
   }
+```
+
+> Note: appleScriptTitledButton can change its icon. To do it, you need to do the following things:
+1. Declarate dictionary of icons in `alternativeImages` field
+2. Make you script return array of two values - `{"TITLE", "IMAGE_LABEL"}`
+3. Make sure that your `IMAGE_LABEL` is declared in `alternativeImages` field
+
+Example:
+```js
+  {
+    "type": "appleScriptTitledButton",
+    "source": {
+      "inline": "if (random number from 1 to 2) = 1 then\n\tset val to {\"title\", \"play\"}\nelse\n\tset val to {\"title\", \"pause\"}\nend if\nreturn val"
+    },
+    "refreshInterval": 1,
+    "image": {
+      "base64": "iVBORw0KGgoAAAANSUhEUgA..."
+    },
+    "alternativeImages": {
+      "play": {
+        "base64": "iVBORw0KGgoAAAANSUhEUgAAAAAA..."
+      },
+      "pause": {
+        "base64": "iVBORw0KGgoAAAANSUhEUgAAAIAA..."
+      }
+    }
+  },
 ```
 
 #### `shellScriptTitledButton`

--- a/README.md
+++ b/README.md
@@ -375,6 +375,31 @@ If you want to longPress for some operations, it is similar to the configuration
   "bordered": "false" // "true" or "false"
 ```
 
+- `background` allow to specify you button background color
+
+```js
+  "background": "#FF0000",
+```
+by using background with color "#000000" and bordered == false you can create button without gray background but with background when the button is pressed
+
+- `title` specify button title
+
+```js
+  "title": "hello"
+```
+
+- `image` specify button icon
+
+```js
+  "image": {
+    //Can be either of those
+    "base64": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAABGdB...."
+    //or
+    "filePath": "~/img.png"
+  }
+```
+
+
 ### Roadmap
 
 - [x] Create the first prototype with TouchBar in Storyboard


### PR DESCRIPTION
In this PR I am refactored current preset parsing system to make it easier to use and scale.

## Problems with current parsing
1. It uses enums which is not very scalable. In current system we have a switch for 20 cases which represent types. Parameters for the presets are mixed up - all of them (29) lies in a single `CodingKeys` enum.
2. It is too broad. There is no single place where all the parameters are read. Some params are read in the ItemType initializator, some in GeneralParameter and so on.
3. We need 5 additional objects to parse:
  * `ItemType`, `ActionType`, `LongActionType`, `GeneralParameter` - initial parsing
  * `BarItemDefinition` - storage for items above
4. Parameters parsing is separated from an actual object. This limits some of the future changes (import preset from BTT)

TL;DR: Current system is good enough, but probably we can do it more scalable?

## Proposal
I propose to make all widgets to be based on a single base class CustomTouchBarItem which would satisfy `Decodable` interface and put all parameter parsing into `init(from decoder: Decoder)`.

### Pros
* Parameter parsing and object creation are close to each other.
* Simpler (in some sense, read below) creation of a new widgets. You only need to correctly implement your class and register it in one(!) place.

### Cons
* Parsing is now mixed up with business logic which is not good too

## Implementation details
All classes are inherited from a base class `CustomTouchBarItem` which satisfy `Decodable`. Each widget inherited from this class override `class var typeIdentifier` to expose its type identifier (for example `appleScriptTitledButton` or `brightnessDown`). Class also need to override `init(from: Decoder)` and parse all custom params. To make this class be visible for the parser you need to add this class into `BarItemDefinition.types` in `ItemParsing.swift`. Here is example how it looks like:

```swift
class NetworkBarItem: CustomButtonTouchBarItem {    
    private let flip: Bool
    
    private enum CodingKeys: String, CodingKey {
        case flip
    }
    
    override class var typeIdentifier: String {
        return "network"
    }
    
    init(identifier: NSTouchBarItem.Identifier, flip: Bool = false) {
        self.flip = flip
        super.init(identifier: identifier, title: " ")
        startMonitoringProcess()
    }

    required init?(coder _: NSCoder) {
        fatalError("init(coder:) has not been implemented")
    }
    
    required init(from decoder: Decoder) throws {
        let container = try decoder.container(keyedBy: CodingKeys.self)
        self.flip = try container.decodeIfPresent(Bool.self, forKey: .flip) ?? false
        
        try super.init(from: decoder)
        startMonitoringProcess()
    }
....
}
```

## Implementation limitations
1. I made `typeIdentifier` to be class var because I wanted to access it before creating class (need in `ItemParsing.swift`). Because of this I cannot enforce that everyone has overrided it and if someone would forget about it it wouldn't be able to load his class even if it is registered.
2. It is easy to create a class which is inherited from `NSCustomTouchBarItem`, but not so simple to inherit from some other types like `NSSlider` or `NSPopoverTouchBarItem`. However it can be done (`BrightnessViewController`, `GroupBarItem`)
3. When creating new Widget you may forget to call `super.init(from: decoder)`. In this case it wouldn't decode basing params like width or text. Again, no way to enforce it.

## Testing
While implementing I have tested all supported widgets. No regression was found. I would provide test preset later

## TODO
1. README
2. Fix tests. Right now they are completely broken and I have no idea how to fix them, because it is some problem with libraries and stuff.