### PR TITLE
Implement multiple actions (double tap, triple tap)

### DIFF
--- a/MTMR/CustomButtonTouchBarItem.swift
+++ b/MTMR/CustomButtonTouchBarItem.swift
@@ -9,16 +9,6 @@
 import Cocoa
 
 class CustomButtonTouchBarItem: NSCustomTouchBarItem, NSGestureRecognizerDelegate {
-    var tapClosure: (() -> Void)? {
-        didSet {
-            actions[.singleTap] = tapClosure
-        }
-    }
-    var longTapClosure: (() -> Void)? {
-        didSet {
-            actions[.longTap] = longTapClosure
-        }
-    }
     typealias TriggerClosure = (() -> Void)?
     var actions: [Action.Trigger: TriggerClosure] = [:] {
         didSet {

--- a/MTMR/ItemsParsing.swift
+++ b/MTMR/ItemsParsing.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension Data {
     func barItemDefinitions() -> [BarItemDefinition]? {
-           return try? JSONDecoder().decode([BarItemDefinition].self, from: utf8string!.stripComments().data(using: .utf8)!)
+           return try! JSONDecoder().decode([BarItemDefinition].self, from: utf8string!.stripComments().data(using: .utf8)!)
     }
 }
 
@@ -51,25 +51,31 @@ class SupportedTypesHolder {
     private var supportedTypes: [String: ParametersDecoder] = [
         "escape": { _ in (
             item: .staticButton(title: "esc"),
-            action: .keyPress(keycode: 53),
+            action: .none,
             longAction: .none,
-            parameters: [.align: .align(.left)]
+            parameters: [.align: .align(.left), .actions: .actions([
+                Action(trigger: .singleTap, value: .keyPress(keycode: 53))
+            ])]
         ) },
 
         "delete": { _ in (
             item: .staticButton(title: "del"),
-            action: .keyPress(keycode: 117),
+            action: .none,
             longAction: .none,
-            parameters: [:]
+            parameters: [.actions: .actions([
+                Action(trigger: .singleTap, value: .keyPress(keycode: 117))
+            ])]
         ) },
 
         "brightnessUp": { _ in
             let imageParameter = GeneralParameter.image(source: #imageLiteral(resourceName: "brightnessUp"))
             return (
                 item: .staticButton(title: ""),
-                action: .keyPress(keycode: 144),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .keyPress(keycode: 144))
+                ])]
             )
         },
 
@@ -77,9 +83,11 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: #imageLiteral(resourceName: "brightnessDown"))
             return (
                 item: .staticButton(title: ""),
-                action: .keyPress(keycode: 145),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .keyPress(keycode: 145))
+                ])]
             )
         },
 
@@ -87,9 +95,11 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: #imageLiteral(resourceName: "ill_up"))
             return (
                 item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_ILLUMINATION_UP),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .hidKey(keycode: NX_KEYTYPE_ILLUMINATION_UP))
+                ])]
             )
         },
 
@@ -97,9 +107,11 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: #imageLiteral(resourceName: "ill_down"))
             return (
                 item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_ILLUMINATION_DOWN),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .hidKey(keycode: NX_KEYTYPE_ILLUMINATION_DOWN))
+                ])]
             )
         },
 
@@ -107,9 +119,11 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarVolumeDownTemplateName)!)
             return (
                 item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_SOUND_DOWN),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .hidKey(keycode: NX_KEYTYPE_SOUND_DOWN))
+                ])]
             )
         },
 
@@ -117,9 +131,11 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarVolumeUpTemplateName)!)
             return (
                 item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_SOUND_UP),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .hidKey(keycode: NX_KEYTYPE_SOUND_UP))
+                ])]
             )
         },
 
@@ -127,9 +143,11 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarAudioOutputMuteTemplateName)!)
             return (
                 item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_MUTE),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .hidKey(keycode: NX_KEYTYPE_MUTE))
+                ])]
             )
         },
 
@@ -137,9 +155,11 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarRewindTemplateName)!)
             return (
                 item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_PREVIOUS),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .hidKey(keycode: NX_KEYTYPE_PREVIOUS))
+                ])]
             )
         },
 
@@ -147,9 +167,11 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarPlayPauseTemplateName)!)
             return (
                 item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_PLAY),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .hidKey(keycode: NX_KEYTYPE_PLAY))
+                ])]
             )
         },
 
@@ -157,24 +179,30 @@ class SupportedTypesHolder {
             let imageParameter = GeneralParameter.image(source: NSImage(named: NSImage.touchBarFastForwardTemplateName)!)
             return (
                 item: .staticButton(title: ""),
-                action: .hidKey(keycode: NX_KEYTYPE_NEXT),
+                action: .none,
                 longAction: .none,
-                parameters: [.image: imageParameter]
+                parameters: [.image: imageParameter, .actions: .actions([
+                    Action(trigger: .singleTap, value: .hidKey(keycode: NX_KEYTYPE_NEXT))
+                ])]
             )
         },
 
         "sleep": { _ in (
             item: .staticButton(title: "☕️"),
-            action: .shellScript(executable: "/usr/bin/pmset", parameters: ["sleepnow"]),
+            action: .none,
             longAction: .none,
-            parameters: [:]
+            parameters: [.actions: .actions([
+                Action(trigger: .singleTap, value: .shellScript(executable: "/usr/bin/pmset", parameters: ["sleepnow"]))
+            ])]
         ) },
 
         "displaySleep": { _ in (
             item: .staticButton(title: "☕️"),
-            action: .shellScript(executable: "/usr/bin/pmset", parameters: ["displaysleepnow"]),
+            action: .none,
             longAction: .none,
-            parameters: [:]
+            parameters: [.actions: .actions([
+                Action(trigger: .singleTap, value: .shellScript(executable: "/usr/bin/pmset", parameters: ["displaysleepnow"]))
+            ])]
         ) },
 
     ]
@@ -393,6 +421,92 @@ enum ItemType: Decodable {
     }
 }
 
+struct FailableDecodable<Base : Decodable> : Decodable {
+
+    let base: Base?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.base = try? container.decode(Base.self)
+    }
+}
+
+struct Action: Decodable {
+    enum Trigger: String, Decodable {
+        case singleTap
+        case doubleTap
+        case longTap
+    }
+    
+    enum Value {
+        case none
+        case hidKey(keycode: Int32)
+        case keyPress(keycode: Int)
+        case appleScript(source: SourceProtocol)
+        case shellScript(executable: String, parameters: [String])
+        case custom(closure: () -> Void)
+        case openUrl(url: String)
+    }
+    
+    private enum ActionTypeRaw: String, Decodable {
+        case hidKey
+        case keyPress
+        case appleScript
+        case shellScript
+        case openUrl
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case trigger
+        case action
+        case keycode
+        case actionAppleScript
+        case executablePath
+        case shellArguments
+        case url
+    }
+    
+    let trigger: Trigger
+    let value: Value
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        trigger = try container.decode(Trigger.self, forKey: .trigger)
+        let type = try container.decodeIfPresent(ActionTypeRaw.self, forKey: .action)
+
+        switch type {
+        case .some(.hidKey):
+            let keycode = try container.decode(Int32.self, forKey: .keycode)
+            value = .hidKey(keycode: keycode)
+
+        case .some(.keyPress):
+            let keycode = try container.decode(Int.self, forKey: .keycode)
+            value = .keyPress(keycode: keycode)
+
+        case .some(.appleScript):
+            let source = try container.decode(Source.self, forKey: .actionAppleScript)
+            value = .appleScript(source: source)
+
+        case .some(.shellScript):
+            let executable = try container.decode(String.self, forKey: .executablePath)
+            let parameters = try container.decodeIfPresent([String].self, forKey: .shellArguments) ?? []
+            value = .shellScript(executable: executable, parameters: parameters)
+
+        case .some(.openUrl):
+            let url = try container.decode(String.self, forKey: .url)
+            value = .openUrl(url: url)
+        case .none:
+            value = .none
+        }
+    }
+    
+    init(trigger: Trigger, value: Value) {
+        self.trigger = trigger
+        self.value = value
+    }
+}
+
 enum ActionType: Decodable {
     case none
     case hidKey(keycode: Int32)
@@ -516,6 +630,7 @@ enum GeneralParameter {
     case bordered(_: Bool)
     case background(_: NSColor)
     case title(_: String)
+    case actions(_: [Action])
 }
 
 struct GeneralParameters: Decodable {
@@ -528,6 +643,7 @@ struct GeneralParameters: Decodable {
         case bordered
         case background
         case title
+        case actions
     }
 
     init(from decoder: Decoder) throws {
@@ -555,6 +671,10 @@ struct GeneralParameters: Decodable {
 
         if let title = try container.decodeIfPresent(String.self, forKey: .title) {
             result[.title] = .title(title)
+        }
+        
+        if let actions = try container.decodeIfPresent([Action].self, forKey: .actions) {
+            result[.actions] = .actions(actions)//.compactMap { $0.base })
         }
 
         parameters = result

--- a/MTMR/ItemsParsing.swift
+++ b/MTMR/ItemsParsing.swift
@@ -456,6 +456,7 @@ struct Action: Decodable {
     enum Trigger: String, Decodable {
         case singleTap
         case doubleTap
+        case tripleTap
         case longTap
     }
     

--- a/MTMR/TouchBarController.swift
+++ b/MTMR/TouchBarController.swift
@@ -323,15 +323,15 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
         }
 
         if let action = self.action(forItem: item), let item = barItem as? CustomButtonTouchBarItem {
-            item.actions[.singleTap] = action
+            item.actions.append(ItemAction(trigger: .singleTap, action))
         }
         if let longAction = self.longAction(forItem: item), let item = barItem as? CustomButtonTouchBarItem {
-            item.actions[.longTap] = longAction
+            item.actions.append(ItemAction(trigger: .longTap, longAction))
         }
         
         if let touchBarItem = barItem as? CustomButtonTouchBarItem {
             for action in item.actions {
-                touchBarItem.actions[action.trigger] = self.closure(for: action)
+                touchBarItem.actions.append(ItemAction(trigger: action.trigger, self.closure(for: action)))
             }
         }
         if case let .bordered(bordered)? = item.additionalParameters[.bordered], let item = barItem as? CustomButtonTouchBarItem {

--- a/MTMR/TouchBarController.swift
+++ b/MTMR/TouchBarController.swift
@@ -323,10 +323,10 @@ class TouchBarController: NSObject, NSTouchBarDelegate {
         }
 
         if let action = self.action(forItem: item), let item = barItem as? CustomButtonTouchBarItem {
-            item.tapClosure = action
+            item.actions[.singleTap] = action
         }
         if let longAction = self.longAction(forItem: item), let item = barItem as? CustomButtonTouchBarItem {
-            item.longTapClosure = longAction
+            item.actions[.longTap] = longAction
         }
         
         if let touchBarItem = barItem as? CustomButtonTouchBarItem {

--- a/MTMR/Widgets/AppScrubberTouchBarItem.swift
+++ b/MTMR/Widgets/AppScrubberTouchBarItem.swift
@@ -82,10 +82,10 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem {
     public func createAppButton(for app: DockItem) -> DockBarItem {
         let item = DockBarItem(app)
         item.isBordered = false
-        item.tapClosure = { [weak self] in
+        item.actions[.singleTap] = { [weak self] in
             self?.switchToApp(app: app)
         }
-        item.longTapClosure = { [weak self] in
+        item.actions[.longTap] = { [weak self] in
             self?.handleHalfLongPress(item: app)
         }
         item.killAppClosure = {[weak self] in

--- a/MTMR/Widgets/AppScrubberTouchBarItem.swift
+++ b/MTMR/Widgets/AppScrubberTouchBarItem.swift
@@ -82,12 +82,14 @@ class AppScrubberTouchBarItem: NSCustomTouchBarItem {
     public func createAppButton(for app: DockItem) -> DockBarItem {
         let item = DockBarItem(app)
         item.isBordered = false
-        item.actions[.singleTap] = { [weak self] in
-            self?.switchToApp(app: app)
-        }
-        item.actions[.longTap] = { [weak self] in
-            self?.handleHalfLongPress(item: app)
-        }
+        item.actions.append(contentsOf: [
+            ItemAction(trigger: .singleTap) { [weak self] in
+                self?.switchToApp(app: app)
+            },
+            ItemAction(trigger: .longTap) { [weak self] in
+                self?.handleHalfLongPress(item: app)
+            }
+        ])
         item.killAppClosure = {[weak self] in
             self?.handleLongPress(item: app)
         }

--- a/MTMR/Widgets/DarkModeBarItem.swift
+++ b/MTMR/Widgets/DarkModeBarItem.swift
@@ -11,7 +11,7 @@ class DarkModeBarItem: CustomButtonTouchBarItem, Widget {
         isBordered = false
         setWidth(value: 24)
 
-        actions[.singleTap] = { [weak self] in self?.DarkModeToggle() }
+        actions.append(ItemAction(trigger: .singleTap) { [weak self] in self?.DarkModeToggle() })
 
         timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
 

--- a/MTMR/Widgets/DarkModeBarItem.swift
+++ b/MTMR/Widgets/DarkModeBarItem.swift
@@ -11,7 +11,7 @@ class DarkModeBarItem: CustomButtonTouchBarItem, Widget {
         isBordered = false
         setWidth(value: 24)
 
-        tapClosure = { [weak self] in self?.DarkModeToggle() }
+        actions[.singleTap] = { [weak self] in self?.DarkModeToggle() }
 
         timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
 

--- a/MTMR/Widgets/DnDBarItem.swift
+++ b/MTMR/Widgets/DnDBarItem.swift
@@ -16,7 +16,7 @@ class DnDBarItem: CustomButtonTouchBarItem {
         isBordered = false
         setWidth(value: 32)
 
-        actions[.singleTap] = { [weak self] in self?.DnDToggle() }
+        actions.append(ItemAction(trigger: .singleTap) { [weak self] in self?.DnDToggle() })
 
         timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
 

--- a/MTMR/Widgets/DnDBarItem.swift
+++ b/MTMR/Widgets/DnDBarItem.swift
@@ -16,7 +16,7 @@ class DnDBarItem: CustomButtonTouchBarItem {
         isBordered = false
         setWidth(value: 32)
 
-        tapClosure = { [weak self] in self?.DnDToggle() }
+        actions[.singleTap] = { [weak self] in self?.DnDToggle() }
 
         timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
 

--- a/MTMR/Widgets/InputSourceBarItem.swift
+++ b/MTMR/Widgets/InputSourceBarItem.swift
@@ -18,9 +18,10 @@ class InputSourceBarItem: CustomButtonTouchBarItem {
 
         observeIputSourceChangedNotification()
         textInputSourceDidChange()
-        actions[.singleTap] = { [weak self] in
+        
+        actions.append(ItemAction(trigger: .singleTap) { [weak self] in
             self?.switchInputSource()
-        }
+        })
     }
 
     required init?(coder _: NSCoder) {

--- a/MTMR/Widgets/InputSourceBarItem.swift
+++ b/MTMR/Widgets/InputSourceBarItem.swift
@@ -18,7 +18,7 @@ class InputSourceBarItem: CustomButtonTouchBarItem {
 
         observeIputSourceChangedNotification()
         textInputSourceDidChange()
-        tapClosure = { [weak self] in
+        actions[.singleTap] = { [weak self] in
             self?.switchInputSource()
         }
     }

--- a/MTMR/Widgets/MusicBarItem.swift
+++ b/MTMR/Widgets/MusicBarItem.swift
@@ -41,9 +41,12 @@ class MusicBarItem: CustomButtonTouchBarItem {
 
         super.init(identifier: identifier, title: "⏳")
         isBordered = false
-
-        tapClosure = { [weak self] in self?.playPause() }
-        longTapClosure = { [weak self] in self?.nextTrack() }
+        
+        actions = [
+            .singleTap: { [weak self] in self?.playPause() },
+            .doubleTap: { [weak self] in self?.previousTrack() },
+            .longTap: { [weak self] in self?.nextTrack() }
+        ]
 
         refreshAndSchedule()
     }
@@ -172,6 +175,31 @@ class MusicBarItem: CustomButtonTouchBarItem {
                                 }
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+    
+    @objc func previousTrack() {
+        for ident in playerBundleIdentifiers {
+            if let musicPlayer = SBApplication(bundleIdentifier: ident.rawValue) {
+                if musicPlayer.isRunning {
+                    if ident == .Spotify {
+                        let mp = (musicPlayer as SpotifyApplication)
+                        mp.previousTrack!()
+                        updatePlayer()
+                        return
+                    } else if ident == .iTunes {
+                        let mp = (musicPlayer as iTunesApplication)
+                        mp.previousTrack!()
+                        updatePlayer()
+                        return
+                    } else if ident == .Music {
+                        let mp = (musicPlayer as MusicApplication)
+                        mp.previousTrack!()
+                        updatePlayer()
+                        return
                     }
                 }
             }

--- a/MTMR/Widgets/MusicBarItem.swift
+++ b/MTMR/Widgets/MusicBarItem.swift
@@ -43,9 +43,9 @@ class MusicBarItem: CustomButtonTouchBarItem {
         isBordered = false
         
         actions = [
-            .singleTap: { [weak self] in self?.playPause() },
-            .doubleTap: { [weak self] in self?.previousTrack() },
-            .longTap: { [weak self] in self?.nextTrack() }
+            ItemAction(trigger: .singleTap) { [weak self] in self?.playPause() },
+            ItemAction(trigger: .doubleTap) { [weak self] in self?.previousTrack() },
+            ItemAction(trigger: .longTap) { [weak self] in self?.nextTrack() }
         ]
 
         refreshAndSchedule()

--- a/MTMR/Widgets/NightShiftBarItem.swift
+++ b/MTMR/Widgets/NightShiftBarItem.swift
@@ -30,8 +30,8 @@ class NightShiftBarItem: CustomButtonTouchBarItem {
         super.init(identifier: identifier, title: "")
         isBordered = false
         setWidth(value: 28)
-
-        actions[.singleTap] = { [weak self] in self?.nightShiftAction() }
+        
+        actions.append(ItemAction(trigger: .singleTap) { [weak self] in self?.nightShiftAction() })
 
         timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
 

--- a/MTMR/Widgets/NightShiftBarItem.swift
+++ b/MTMR/Widgets/NightShiftBarItem.swift
@@ -31,7 +31,7 @@ class NightShiftBarItem: CustomButtonTouchBarItem {
         isBordered = false
         setWidth(value: 28)
 
-        tapClosure = { [weak self] in self?.nightShiftAction() }
+        actions[.singleTap] = { [weak self] in self?.nightShiftAction() }
 
         timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(refresh), userInfo: nil, repeats: true)
 

--- a/MTMR/Widgets/PomodoroBarItem.swift
+++ b/MTMR/Widgets/PomodoroBarItem.swift
@@ -50,8 +50,10 @@ class PomodoroBarItem: CustomButtonTouchBarItem, Widget {
         self.workTime = workTime
         self.restTime = restTime
         super.init(identifier: identifier, title: defaultTitle)
-        tapClosure = { [weak self] in self?.startStopWork() }
-        longTapClosure = { [weak self] in self?.startStopRest() }
+        actions = [
+            .singleTap: { [weak self] in self?.startStopWork() },
+            .longTap: { [weak self] in self?.startStopRest() }
+        ]
     }
 
     required init?(coder _: NSCoder) {

--- a/MTMR/Widgets/PomodoroBarItem.swift
+++ b/MTMR/Widgets/PomodoroBarItem.swift
@@ -51,10 +51,10 @@ class PomodoroBarItem: CustomButtonTouchBarItem, Widget {
         self.workTime = workTime
         self.restTime = restTime
         super.init(identifier: identifier, title: defaultTitle)
-        actions = [
-            .singleTap: { [weak self] in self?.startStopWork() },
-            .longTap: { [weak self] in self?.startStopRest() }
-        ]
+        actions.append(contentsOf: [
+            ItemAction(trigger: .singleTap) { [weak self] in self?.startStopWork() },
+            ItemAction(trigger: .longTap) { [weak self] in self?.startStopRest() }
+        ])
     }
 
     required init?(coder _: NSCoder) {

--- a/MTMR/Widgets/PomodoroBarItem.swift
+++ b/MTMR/Widgets/PomodoroBarItem.swift
@@ -23,8 +23,9 @@ class PomodoroBarItem: CustomButtonTouchBarItem, Widget {
 
         return (
             item: .pomodoro(workTime: workTime ?? 1500.00, restTime: restTime ?? 300),
-            action: .none,
-            longAction: .none,
+            actions: [],
+            legacyAction: .none,
+            legacyLongAction: .none,
             parameters: [:]
         )
     }

--- a/MTMR/Widgets/UpNextScrubberTouchBarItem.swift
+++ b/MTMR/Widgets/UpNextScrubberTouchBarItem.swift
@@ -75,9 +75,9 @@ class UpNextScrubberTouchBarItem: NSCustomTouchBarItem {
                 let item = UpNextItem(event: event)
                 item.backgroundColor = self.getBackgroundColor(startDate: event.startDate)
                 // Bind tap event
-                item.actions[.singleTap] = { [weak self] in
+                item.actions.append(ItemAction(trigger: .singleTap) { [weak self] in
                     self?.switchToApp(event: event)
-                }
+                })
                 // Add to view
                 self.items.append(item)
                 // Check if should display any more

--- a/MTMR/Widgets/UpNextScrubberTouchBarItem.swift
+++ b/MTMR/Widgets/UpNextScrubberTouchBarItem.swift
@@ -75,7 +75,7 @@ class UpNextScrubberTouchBarItem: NSCustomTouchBarItem {
                 let item = UpNextItem(event: event)
                 item.backgroundColor = self.getBackgroundColor(startDate: event.startDate)
                 // Bind tap event
-                item.tapClosure = { [weak self] in
+                item.actions[.singleTap] = { [weak self] in
                     self?.switchToApp(event: event)
                 }
                 // Add to view

--- a/MTMR/Widgets/YandexWeatherBarItem.swift
+++ b/MTMR/Widgets/YandexWeatherBarItem.swift
@@ -50,8 +50,13 @@ class YandexWeatherBarItem: CustomButtonTouchBarItem, CLLocationManagerDelegate 
         manager.delegate = self
         manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         manager.startUpdatingLocation()
-
-        actions[.singleTap] = actions[.singleTap] ?? defaultTapAction
+        
+        if actions.filter({ $0.trigger == .singleTap }).isEmpty {
+            actions.append(ItemAction(
+                trigger: .singleTap,
+                defaultTapAction
+            ))
+        }
     }
 
     required init?(coder _: NSCoder) {

--- a/MTMR/Widgets/YandexWeatherBarItem.swift
+++ b/MTMR/Widgets/YandexWeatherBarItem.swift
@@ -51,7 +51,7 @@ class YandexWeatherBarItem: CustomButtonTouchBarItem, CLLocationManagerDelegate 
         manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         manager.startUpdatingLocation()
 
-        tapClosure = tapClosure ?? defaultTapAction
+        actions[.singleTap] = actions[.singleTap] ?? defaultTapAction
     }
 
     required init?(coder _: NSCoder) {

--- a/MTMRTests/ParseConfigTests.swift
+++ b/MTMRTests/ParseConfigTests.swift
@@ -40,7 +40,8 @@ class ParseConfig: XCTestCase {
             XCTFail()
             return
         }
-        guard case .keyPress(keycode: 53)? = result?.first?.action else {
+        let parameter = result?.first?.additionalParameters[.actions]
+        guard case .actions(let actions) = parameter, case .keyPress(keycode: 53)? = actions.filter({ $0.trigger == .singleTap }).first?.value else {
             XCTFail()
             return
         }
@@ -55,7 +56,8 @@ class ParseConfig: XCTestCase {
             XCTFail()
             return
         }
-        guard case .keyPress(keycode: 53)? = result?.first?.action else {
+        let parameter = result?.first?.additionalParameters[.actions]
+        guard case .actions(let actions) = parameter, case .keyPress(keycode: 53)? = actions.filter({ $0.trigger == .singleTap }).first?.value else {
             XCTFail()
             return
         }

--- a/MTMRTests/ParseConfigTests.swift
+++ b/MTMRTests/ParseConfigTests.swift
@@ -30,6 +30,21 @@ class ParseConfig: XCTestCase {
             return
         }
     }
+    
+    func testButtonKeyCodeLegacyAction() {
+        let buttonKeycodeFixture = """
+            [  { "type": "staticButton",  "title": "Pew", "action": "hidKey", "keycode": 123 } ]
+        """.data(using: .utf8)!
+        let result = try? JSONDecoder().decode([BarItemDefinition].self, from: buttonKeycodeFixture)
+        guard case .staticButton("Pew")? = result?.first?.type else {
+            XCTFail()
+            return
+        }
+        guard case .hidKey(keycode: 123)? = result?.first?.legacyAction else {
+            XCTFail()
+            return
+        }
+    }
 
     func testPredefinedItem() {
         let buttonKeycodeFixture = """

--- a/MTMRTests/ParseConfigTests.swift
+++ b/MTMRTests/ParseConfigTests.swift
@@ -10,7 +10,7 @@ class ParseConfig: XCTestCase {
             XCTFail()
             return
         }
-        guard case .none? = result?.first?.action else {
+        guard result?.first?.actions.count == 0 else {
             XCTFail()
             return
         }
@@ -18,14 +18,14 @@ class ParseConfig: XCTestCase {
 
     func testButtonKeyCodeAction() {
         let buttonKeycodeFixture = """
-            [  { "type": "staticButton",  "title": "Pew", "action": "hidKey", "keycode": 123} ]
+            [  { "type": "staticButton",  "title": "Pew", "actions": [ { "trigger": "singleTap", "action": "hidKey", "keycode": 123 } ] } ]
         """.data(using: .utf8)!
         let result = try? JSONDecoder().decode([BarItemDefinition].self, from: buttonKeycodeFixture)
         guard case .staticButton("Pew")? = result?.first?.type else {
             XCTFail()
             return
         }
-        guard case .hidKey(keycode: 123)? = result?.first?.action else {
+        guard case .hidKey(keycode: 123)? = result?.first?.actions.filter({ $0.trigger == .singleTap }).first?.value else {
             XCTFail()
             return
         }
@@ -40,8 +40,7 @@ class ParseConfig: XCTestCase {
             XCTFail()
             return
         }
-        let parameter = result?.first?.additionalParameters[.actions]
-        guard case .actions(let actions) = parameter, case .keyPress(keycode: 53)? = actions.filter({ $0.trigger == .singleTap }).first?.value else {
+        guard case .keyPress(keycode: 53)? = result?.first?.actions.filter({ $0.trigger == .singleTap }).first?.value else {
             XCTFail()
             return
         }
@@ -56,8 +55,7 @@ class ParseConfig: XCTestCase {
             XCTFail()
             return
         }
-        let parameter = result?.first?.additionalParameters[.actions]
-        guard case .actions(let actions) = parameter, case .keyPress(keycode: 53)? = actions.filter({ $0.trigger == .singleTap }).first?.value else {
+        guard case .keyPress(keycode: 53)? = result?.first?.actions.filter({ $0.trigger == .singleTap }).first?.value else {
             XCTFail()
             return
         }

--- a/README.md
+++ b/README.md
@@ -198,10 +198,15 @@ Example of "CPU load" button which also changes color based on load value.
   "source": {
     "inline": "top -l 2 -n 0 -F | egrep -o ' \\d*\\.\\d+% idle' | tail -1 | awk -F% '{p = 100 - $1; if (p > 30) c = \"\\033[33m\"; if (p > 70) c = \"\\033[30;43m\"; printf \"%s%4.1f%%\\n\", c, p}'"
   },
-  "action": "appleScript",
-  "actionAppleScript": {
-    "inline": "activate application \"Activity Monitor\"\rtell application \"System Events\"\r\ttell process \"Activity Monitor\"\r\t\ttell radio button \"CPU\" of radio group 1 of group 2 of toolbar 1 of window 1 to perform action \"AXPress\"\r\tend tell\rend tell"
-  },
+  "actions": [
+    {
+      "trigger": "singleTap",
+      "action": "appleScript",
+      "actionAppleScript": {
+        "inline": "activate application \"Activity Monitor\"\rtell application \"System Events\"\r\ttell process \"Activity Monitor\"\r\t\ttell radio button \"CPU\" of radio group 1 of group 2 of toolbar 1 of window 1 to perform action \"AXPress\"\r\tend tell\rend tell"
+      }
+    }
+  ],
   "align": "right",
   "image": {
     // Or you can specify a filePath here.
@@ -363,6 +368,27 @@ Displays upcoming events from MacOS Calendar.  Does not display current event.
 
 ## Actions:
 
+### Example:
+
+```js
+"actions": [
+  {
+    "trigger": "singleTap",
+    "action": "hidKey",
+    "keycode": 53
+  }
+]
+```
+
+### Triggers:
+
+- `singleTap`
+- `doubleTap`
+- `tripleTap`
+- `longTap`
+
+### Types
+
 - `hidKey`
   > https://github.com/aosm/IOHIDFamily/blob/master/IOHIDSystem/IOKit/hidsystem/ev_keymap.h use only numbers
 
@@ -403,22 +429,6 @@ Displays upcoming events from MacOS Calendar.  Does not display current event.
  "action": "openUrl",
  "url": "https://google.com",
 ```
-
-## LongActions
-
-If you want to longPress for some operations, it is similar to the configuration for Actions but with additional parameters, for example:
-
-```js
- "longAction": "hidKey",
- "longKeycode": 53,
-```
-
-- longAction
-- longKeycode
-- longActionAppleScript
-- longExecutablePath
-- longShellArguments
-- longUrl
 
 ## Additional parameters:
 


### PR DESCRIPTION
This PR implements:
- A new double tap trigger
- A new triple tap trigger
- Support for multiple actions and same trigger (just define multiple actions with same trigger type)
- A brand new `actions` parameter in config. Example:
```json
{
      "type": "staticButton",
      "title": "test",
      "actions": [
          {
              "trigger": "singleTap",
              "action": "shellScript",
              "executablePath": "/usr/bin/say",
              "shellArguments": ["Single"]
          },
          {
              "trigger": "doubleTap",
              "action": "shellScript",
              "executablePath": "/usr/bin/say",
              "shellArguments": ["Double"]
          },
          {
              "trigger": "longTap",
              "action": "shellScript",
              "executablePath": "/usr/bin/say",
              "shellArguments": ["Long"]
          }
      ]
  }
```
- Old `action` and `longAction` works normally, i retained the legacy code to not break compatibility.