### PR TITLE
Add PLN and UAH signs to CurrencyBarItem.swift

### DIFF
--- a/MTMR/Widgets/CurrencyBarItem.swift
+++ b/MTMR/Widgets/CurrencyBarItem.swift
@@ -42,7 +42,9 @@ class CurrencyBarItem: CustomButtonTouchBarItem {
         "DOT": "●",
         "DOGE": "Ð",
         "XMR": "ɱ",
-        "ADA": "₳"
+        "ADA": "₳",
+        "PLN": "zł",
+        "UAH": "₴",
     ]
     private let decimals = [
         "USD": 4,


### PR DESCRIPTION
I just added PLN sign (zł) and UAH sign (₴) to give more flexibility for some people from Eastern Europe. Currently it looks like: "PLN9.53".