### PR TITLE
fix: discord broken logo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ My idea is to create a platform for creating plugins to customize the TouchBar. 
 </p>
 
 <p align="center">
-<a href="https://discord.gg/CmNcDuQ"><img height="20px" src="https://camo.githubusercontent.com/88f53948f291c54736bf08f5fd7b037a848dfc62/68747470733a2f2f646973636f72646170702e636f6d2f6173736574732f30376463613830613130326434313439653937333664346231363263666636662e69636f"> Discord</a>
+<a href="https://discord.gg/CmNcDuQ"><img height="20px" src="https://assets-global.website-files.com/6257adef93867e50d84d30e2/62fddf0fde45a8baedcc7ee5_847541504914fd33810e70a0ea73177e%20(2)-1.png"> Discord</a>
 <a href="https://t.me/joinchat/AmVYGg8vW38c13_3MxdE_g"><img height="20px" src="https://telegram.org/img/t_logo.png" /> Telegram</a>
 </p>
 


### PR DESCRIPTION
As you can see here, the Discord logo url was broken.

<img width="1115" alt="Showing a broken discord logo in the README.md" src="https://github.com/Toxblh/MTMR/assets/71392160/0f84e6bd-3704-4b00-a78c-f2094ff608bd">

I made a temporary replace, but it will be best if Telegram and Discord logos were added inside the `Resources` directory.